### PR TITLE
refactor: use Record type directly for isReadyCheck()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frmscoe/frms-coe-lib",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@frmscoe/frms-coe-lib",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "ISC",
       "dependencies": {
         "@log4js-node/logstash-http": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frmscoe/frms-coe-lib",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/services/dbManager.ts
+++ b/src/services/dbManager.ts
@@ -8,7 +8,7 @@ import { RedisService, type RedisConfig } from '..';
 import { AccountType, type TransactionRelationship } from '../interfaces';
 import { dbConfiguration, dbNetworkMap, dbPseudonyms, dbTransactions } from '../interfaces/ArangoCollections';
 
-const readyChecks: any[] = [];
+let readyChecks: Record<string, string | unknown> = {};
 
 interface DBConfig {
   url: string;
@@ -537,7 +537,7 @@ type DatabaseManagerInstance<T extends ManagerConfig> = ManagerStatus &
  */
 export async function CreateDatabaseManager<T extends ManagerConfig>(config: T): Promise<DatabaseManagerInstance<T>> {
   const manager: DatabaseManagerType = {};
-  readyChecks.splice(0, readyChecks.length);
+  readyChecks = {};
   const redis = config.redisConfig ? await redisBuilder(manager, config.redisConfig) : null;
 
   if (config.pseudonyms) {
@@ -556,7 +556,7 @@ export async function CreateDatabaseManager<T extends ManagerConfig>(config: T):
     await networkMapBuilder(manager, config.networkMap);
   }
 
-  manager.isReadyCheck = () => readyChecks.reduce((acc, obj) => ({ ...acc, ...obj }), {});
+  manager.isReadyCheck = () => readyChecks;
 
   manager.quit = () => {
     redis?.quit();
@@ -575,11 +575,11 @@ async function redisBuilder(manager: DatabaseManagerType, redisConfig: RedisConf
     manager.getMembers = redis.getMembers;
     manager.setJson = redis.setJson;
     manager.deleteKey = redis.deleteKey;
-    readyChecks.push({ Redis: 'Ok' });
+    readyChecks.Redis = 'Ok';
 
     return redis;
   } catch (error) {
-    readyChecks.push({ Redis: error });
+    readyChecks.Redis = error;
   }
 }
 
@@ -598,9 +598,9 @@ async function pseudonymsBuilder(manager: DatabaseManagerType, pseudonymsConfig:
 
   try {
     await isDatabaseReady(manager._pseudonymsDb);
-    readyChecks.push({ PseudonymsDB: 'Ok' });
+    readyChecks.PseudonymsDB = 'Ok';
   } catch (err) {
-    readyChecks.push({ PseudonymsDB: err });
+    readyChecks.PseudonymsDB = err;
   }
 
   manager.queryPseudonymDB = async (collection: string, filter: string, limit?: number) => {
@@ -855,9 +855,9 @@ async function transactionHistoryBuilder(manager: DatabaseManagerType, transacti
 
   try {
     await isDatabaseReady(manager._transactionHistory);
-    readyChecks.push({ TransactionHistoryDB: 'Ok' });
+    readyChecks.TransactionHistoryDB = 'Ok';
   } catch (err) {
-    readyChecks.push({ TransactionHistoryDB: err });
+    readyChecks.TransactionHistoryDB = err;
   }
 
   manager.queryTransactionDB = async (collection: string, filter: string, limit?: number) => {
@@ -1052,9 +1052,9 @@ async function configurationBuilder(manager: DatabaseManagerType, configurationC
 
   try {
     await isDatabaseReady(manager._configuration);
-    readyChecks.push({ ConfigurationDB: 'Ok' });
+    readyChecks.ConfigurationDB = 'Ok';
   } catch (err) {
-    readyChecks.push({ ConfigurationDB: err });
+    readyChecks.ConfigurationDB = err;
   }
 
   manager.setupConfig = configurationConfig;
@@ -1112,9 +1112,9 @@ async function networkMapBuilder(manager: DatabaseManagerType, NetworkMapConfig:
 
   try {
     await isDatabaseReady(manager._networkMap);
-    readyChecks.push({ NetworkMapDB: 'Ok' });
+    readyChecks.NetworkMapDB = 'Ok';
   } catch (err) {
-    readyChecks.push({ NetworkMapDB: err });
+    readyChecks.NetworkMapDB = err;
   }
 
   manager.getNetworkMap = async () => {


### PR DESCRIPTION
`isReadyCheck()` returns a `Record<string, unknown>` derived from a list internally. This allows us to return it directly 