### PR TITLE
refactor: use upstream ApmOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frmscoe/frms-coe-lib",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@frmscoe/frms-coe-lib",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "ISC",
       "dependencies": {
         "@log4js-node/logstash-http": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frmscoe/frms-coe-lib",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/interfaces/apm.ts
+++ b/src/interfaces/apm.ts
@@ -1,7 +1,0 @@
-export interface ApmConfig {
-  serviceName: string;
-  secretToken: string;
-  serverUrl: string;
-  usePathAsTransactionName: boolean;
-  active: boolean;
-}

--- a/src/services/apm.ts
+++ b/src/services/apm.ts
@@ -1,23 +1,14 @@
-import apm, { type TransactionOptions } from 'elastic-apm-node';
-import { type ApmConfig } from '../interfaces/apm';
+import apm, { type AgentConfigOptions, type TransactionOptions } from 'elastic-apm-node';
 
 export class Apm {
   #transaction: (name: string, options?: TransactionOptions) => apm.Transaction | null = () => null;
   #span: (name: string) => apm.Span | null = () => null;
   #traceParent: () => string | null = () => null;
 
-  constructor(apmOptions?: ApmConfig) {
+  constructor(apmOptions?: AgentConfigOptions) {
     const apmEnabled = apmOptions && apmOptions.active;
     if (apmEnabled) {
-      const { serviceName, secretToken, serverUrl, usePathAsTransactionName } = apmOptions;
-
-      apm.start({
-        serviceName,
-        secretToken,
-        serverUrl,
-        usePathAsTransactionName,
-        active: apmEnabled,
-      });
+      apm.start(apmOptions);
 
       this.#transaction = (name: string, options?: TransactionOptions): apm.Transaction | null => apm.startTransaction(name, options);
       this.#span = (name: string): apm.Span | null => apm.startSpan(name);


### PR DESCRIPTION
This should help keep the interface to the underlying `elastic-apm` agent always compatible.
Related to https://github.com/frmscoe/General-Issues/issues/238