### PR TITLE
fix: make `status` optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frmscoe/frms-coe-lib",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frmscoe/frms-coe-lib",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "ISC",
       "dependencies": {
         "@log4js-node/logstash-http": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frmscoe/frms-coe-lib",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/helpers/schemas/message.ts
+++ b/src/helpers/schemas/message.ts
@@ -93,7 +93,7 @@ export const messageSchema = {
           },
         },
       },
-      required: ['prcgTm', 'result', 'cfg', 'id', 'status', 'typologyResult'],
+      required: ['prcgTm', 'result', 'cfg', 'id', 'typologyResult'],
     },
     tadpResult: {
       type: 'object',


### PR DESCRIPTION
`status` field is not included in the message to `tadproc`