### PR TITLE
feat: disable log levels below the configured level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frmscoe/frms-coe-lib",
-  "version": "0.4.3",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frmscoe/frms-coe-lib",
-      "version": "0.4.3",
+      "version": "0.5.1",
       "license": "ISC",
       "dependencies": {
         "@log4js-node/logstash-http": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frmscoe/frms-coe-lib",
-  "version": "0.4.3",
+  "version": "0.5.1",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -32,6 +32,10 @@ const createTimeStamp = (): string => {
 };
 
 export class LoggerService {
+  /*
+   * Internal fields are called by the class when each respective method is called
+   *
+   * Each field is by default `null`, see `constructor()` for how each log level is set */
   #info: (message: string, serviceOperation?: string) => void = () => null;
   #debug: (message: string, serviceOperation?: string) => void = () => null;
   #trace: (message: string, serviceOperation?: string) => void = () => null;
@@ -39,6 +43,7 @@ export class LoggerService {
   #error: (message: string | Error, innerError?: unknown, serviceOperation?: string) => void = () => null;
   constructor() {
     switch (config.logger.logstashLevel) {
+      // error > warn > info > debug > trace
       case 'trace':
         this.#trace = this.#createLogCallback('trace');
         this.#debug = this.#createLogCallback('debug');

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -92,20 +92,19 @@ export class LoggerService {
     switch (level) {
       case 'trace':
         return (message: string, serviceOperation?: string): void => {
-          logger.trace(`${this.messageStamp(serviceOperation)}[${level.toUpperCase()}] - ${message}`);
+          logger.trace(`${this.messageStamp(serviceOperation)}[TRACE] - ${message}`);
         };
       case 'debug':
         return (message: string, serviceOperation?: string): void => {
-          logger.debug(`${this.messageStamp(serviceOperation)}[${level.toUpperCase()}] - ${message}`);
+          logger.debug(`${this.messageStamp(serviceOperation)}[DEBUG] - ${message}`);
         };
       case 'warn':
         return (message: string, serviceOperation?: string): void => {
-          logger.warn(`${this.messageStamp(serviceOperation)}[${level.toUpperCase()}] - ${message}`);
+          logger.warn(`${this.messageStamp(serviceOperation)}[WARN] - ${message}`);
         };
-
       default:
         return (message: string, serviceOperation?: string): void => {
-          logger.info(`${this.messageStamp(serviceOperation)}[${level.toUpperCase()}] - ${message}`);
+          logger.info(`${this.messageStamp(serviceOperation)}[INFO] - ${message}`);
         };
     }
   }

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -43,38 +43,35 @@ export class LoggerService {
   #warn: (message: string, serviceOperation?: string) => void = () => null;
   #error: (message: string | Error, innerError?: unknown, serviceOperation?: string) => void = () => null;
   constructor() {
-    // enable logging only if we're on a dev environment or apm logging is activated
-    if (config.apmLogging || devEnv) {
-      switch (config.logger.logstashLevel) {
-        // error > warn > info > debug > trace
-        case 'trace':
-          this.#trace = this.#createLogCallback('trace');
-          this.#debug = this.#createLogCallback('debug');
-          this.#info = this.#createLogCallback('info');
-          this.#warn = this.#createLogCallback('warn');
-          this.#error = this.#createErrorFn();
-          break;
-        case 'debug':
-          this.#debug = this.#createLogCallback('debug');
-          this.#info = this.#createLogCallback('info');
-          this.#warn = this.#createLogCallback('warn');
-          this.#error = this.#createErrorFn();
-          break;
-        case 'info':
-          this.#info = this.#createLogCallback('info');
-          this.#warn = this.#createLogCallback('warn');
-          this.#error = this.#createErrorFn();
-          break;
-        case 'warn':
-          this.#warn = this.#createLogCallback('warn');
-          this.#error = this.#createErrorFn();
-          break;
-        case 'error':
-          this.#error = this.#createErrorFn();
-          break;
-        default:
-          break;
-      }
+    switch (config.logger.logstashLevel.toLowerCase()) {
+      // error > warn > info > debug > trace
+      case 'trace':
+        this.#trace = this.#createLogCallback('trace');
+        this.#debug = this.#createLogCallback('debug');
+        this.#info = this.#createLogCallback('info');
+        this.#warn = this.#createLogCallback('warn');
+        this.#error = this.#createErrorFn();
+        break;
+      case 'debug':
+        this.#debug = this.#createLogCallback('debug');
+        this.#info = this.#createLogCallback('info');
+        this.#warn = this.#createLogCallback('warn');
+        this.#error = this.#createErrorFn();
+        break;
+      case 'info':
+        this.#info = this.#createLogCallback('info');
+        this.#warn = this.#createLogCallback('warn');
+        this.#error = this.#createErrorFn();
+        break;
+      case 'warn':
+        this.#warn = this.#createLogCallback('warn');
+        this.#error = this.#createErrorFn();
+        break;
+      case 'error':
+        this.#error = this.#createErrorFn();
+        break;
+      default:
+        break;
     }
   }
 

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -43,7 +43,7 @@ export class LoggerService {
   #warn: (message: string, serviceOperation?: string) => void = () => null;
   #error: (message: string | Error, innerError?: unknown, serviceOperation?: string) => void = () => null;
   constructor() {
-    // enable logging only if we're on a dev environment and apm logging is activated
+    // enable logging only if we're on a dev environment or apm logging is activated
     if (config.apmLogging || devEnv) {
       switch (config.logger.logstashLevel) {
         // error > warn > info > debug > trace

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -38,36 +38,34 @@ export class LoggerService {
   #warn: (message: string, serviceOperation?: string) => void = () => null;
   #error: (message: string | Error, innerError?: unknown, serviceOperation?: string) => void = () => null;
   constructor() {
-    if (config.apmLogging) {
-      switch (config.logger.logstashLevel) {
-        case 'trace':
-          this.#trace = this.#createLogCallback('trace');
-          this.#debug = this.#createLogCallback('debug');
-          this.#info = this.#createLogCallback('info');
-          this.#warn = this.#createLogCallback('warn');
-          this.#error = this.#createErrorFn();
-          break;
-        case 'debug':
-          this.#debug = this.#createLogCallback('debug');
-          this.#info = this.#createLogCallback('info');
-          this.#warn = this.#createLogCallback('warn');
-          this.#error = this.#createErrorFn();
-          break;
-        case 'info':
-          this.#info = this.#createLogCallback('info');
-          this.#warn = this.#createLogCallback('warn');
-          this.#error = this.#createErrorFn();
-          break;
-        case 'warn':
-          this.#warn = this.#createLogCallback('warn');
-          this.#error = this.#createErrorFn();
-          break;
-        case 'error':
-          this.#error = this.#createErrorFn();
-          break;
-        default:
-          break;
-      }
+    switch (config.logger.logstashLevel) {
+      case 'trace':
+        this.#trace = this.#createLogCallback('trace');
+        this.#debug = this.#createLogCallback('debug');
+        this.#info = this.#createLogCallback('info');
+        this.#warn = this.#createLogCallback('warn');
+        this.#error = this.#createErrorFn();
+        break;
+      case 'debug':
+        this.#debug = this.#createLogCallback('debug');
+        this.#info = this.#createLogCallback('info');
+        this.#warn = this.#createLogCallback('warn');
+        this.#error = this.#createErrorFn();
+        break;
+      case 'info':
+        this.#info = this.#createLogCallback('info');
+        this.#warn = this.#createLogCallback('warn');
+        this.#error = this.#createErrorFn();
+        break;
+      case 'warn':
+        this.#warn = this.#createLogCallback('warn');
+        this.#error = this.#createErrorFn();
+        break;
+      case 'error':
+        this.#error = this.#createErrorFn();
+        break;
+      default:
+        break;
     }
   }
 

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -18,7 +18,8 @@ if (config.nodeEnv !== 'dev' && config.nodeEnv !== 'test') {
   });
 }
 
-const logger = config.nodeEnv === 'dev' || config.nodeEnv === 'test' ? console : log4js.getLogger();
+const devEnv = config.nodeEnv === 'dev' || config.nodeEnv === 'test';
+const logger = devEnv ? console : log4js.getLogger();
 
 const createTimeStamp = (): string => {
   const dateObj = new Date();
@@ -42,35 +43,38 @@ export class LoggerService {
   #warn: (message: string, serviceOperation?: string) => void = () => null;
   #error: (message: string | Error, innerError?: unknown, serviceOperation?: string) => void = () => null;
   constructor() {
-    switch (config.logger.logstashLevel) {
-      // error > warn > info > debug > trace
-      case 'trace':
-        this.#trace = this.#createLogCallback('trace');
-        this.#debug = this.#createLogCallback('debug');
-        this.#info = this.#createLogCallback('info');
-        this.#warn = this.#createLogCallback('warn');
-        this.#error = this.#createErrorFn();
-        break;
-      case 'debug':
-        this.#debug = this.#createLogCallback('debug');
-        this.#info = this.#createLogCallback('info');
-        this.#warn = this.#createLogCallback('warn');
-        this.#error = this.#createErrorFn();
-        break;
-      case 'info':
-        this.#info = this.#createLogCallback('info');
-        this.#warn = this.#createLogCallback('warn');
-        this.#error = this.#createErrorFn();
-        break;
-      case 'warn':
-        this.#warn = this.#createLogCallback('warn');
-        this.#error = this.#createErrorFn();
-        break;
-      case 'error':
-        this.#error = this.#createErrorFn();
-        break;
-      default:
-        break;
+    // enable logging only if we're on a dev environment and apm logging is activated
+    if (config.apmLogging || devEnv) {
+      switch (config.logger.logstashLevel) {
+        // error > warn > info > debug > trace
+        case 'trace':
+          this.#trace = this.#createLogCallback('trace');
+          this.#debug = this.#createLogCallback('debug');
+          this.#info = this.#createLogCallback('info');
+          this.#warn = this.#createLogCallback('warn');
+          this.#error = this.#createErrorFn();
+          break;
+        case 'debug':
+          this.#debug = this.#createLogCallback('debug');
+          this.#info = this.#createLogCallback('info');
+          this.#warn = this.#createLogCallback('warn');
+          this.#error = this.#createErrorFn();
+          break;
+        case 'info':
+          this.#info = this.#createLogCallback('info');
+          this.#warn = this.#createLogCallback('warn');
+          this.#error = this.#createErrorFn();
+          break;
+        case 'warn':
+          this.#warn = this.#createLogCallback('warn');
+          this.#error = this.#createErrorFn();
+          break;
+        case 'error':
+          this.#error = this.#createErrorFn();
+          break;
+        default:
+          break;
+      }
     }
   }
 

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -18,19 +18,7 @@ if (config.nodeEnv !== 'dev' && config.nodeEnv !== 'test') {
   });
 }
 
-const devEnv = config.nodeEnv === 'dev' || config.nodeEnv === 'test';
-const logger = devEnv ? console : log4js.getLogger();
-
-const createTimeStamp = (): string => {
-  const dateObj = new Date();
-
-  let date = dateObj.toISOString();
-  date = date.substring(0, date.indexOf('T'));
-
-  const time = dateObj.toLocaleTimeString([], { hour12: false });
-
-  return `${date} ${time}`;
-};
+const logger = config.nodeEnv === 'dev' || config.nodeEnv === 'test' ? console : log4js.getLogger();
 
 export class LoggerService {
   /*
@@ -76,7 +64,14 @@ export class LoggerService {
   }
 
   timeStamp(): string {
-    return createTimeStamp();
+    const dateObj = new Date();
+
+    let date = dateObj.toISOString();
+    date = date.substring(0, date.indexOf('T'));
+
+    const time = dateObj.toLocaleTimeString([], { hour12: false });
+
+    return `${date} ${time}`;
   }
 
   #createErrorFn(): (message: string | Error, innerError?: unknown, serviceOperation?: string) => void {


### PR DESCRIPTION
Related to https://github.com/frmscoe/General-Issues/issues/254

This PR initialises **all** `log` calls below the configured level to return `null`, bypassing the need to check every time what log level was configured and whether or not we can output the current log.