### PR TITLE
fix: register `getBuffer` method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frmscoe/frms-coe-lib",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frmscoe/frms-coe-lib",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "ISC",
       "dependencies": {
         "@log4js-node/logstash-http": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frmscoe/frms-coe-lib",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/builders/redisBuilder.ts
+++ b/src/builders/redisBuilder.ts
@@ -8,6 +8,7 @@ export async function redisBuilder(manager: DatabaseManagerType, redisConfig: Re
     const redis = await RedisService.create(redisConfig);
     manager._redisClient = redis._redisClient;
     manager.getJson = redis.getJson;
+    manager.getBuffer = redis.getBuffer;
     manager.getMembers = redis.getMembers;
     manager.getMemberValues = redis.getMemberValues;
     manager.deleteKey = redis.deleteKey;


### PR DESCRIPTION
Allows clients to be able to call `getBuffer()` from the database mgr.