### PR TITLE
feat: attaching cache to transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frmscoe/frms-coe-lib",
-  "version": "4.0.0-rc.10",
+  "version": "4.0.0-rc.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frmscoe/frms-coe-lib",
-      "version": "4.0.0-rc.10",
+      "version": "4.0.0-rc.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frmscoe/frms-coe-lib",
-  "version": "4.0.0-rc.10",
+  "version": "4.0.0-rc.11",
   "description": "FRMS Center of Excellence package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/interfaces/Pacs.002.001.12.ts
+++ b/src/interfaces/Pacs.002.001.12.ts
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { type DataCache } from './rule/DataCache';
+
 export interface Pacs002 {
   TxTp: string;
   FIToFIPmtSts: FIToFIPmtSts;
   _key?: string;
+  DataCache?: DataCache;
 }
 
 interface FIToFIPmtSts {

--- a/src/interfaces/Pacs.008.001.10.ts
+++ b/src/interfaces/Pacs.008.001.10.ts
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { type DataCache } from './rule/DataCache';
+
 export interface Pacs008 {
   TxTp: string;
   FIToFICstmrCdtTrf: FIToFICstmrCdtTrf;
   _key?: string;
+  DataCache?: DataCache;
 }
 
 interface FIToFICstmrCdtTrf {

--- a/src/interfaces/Pain.001.001.11.ts
+++ b/src/interfaces/Pain.001.001.11.ts
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { type DataCache } from './rule/DataCache';
+
 export interface Pain001 {
   TxTp: string;
   CstmrCdtTrfInitn: CstmrCdtTrfInitn;
   _key?: string;
+  DataCache?: DataCache;
 }
 
 interface CstmrCdtTrfInitn {

--- a/src/interfaces/Pain.013.001.09.ts
+++ b/src/interfaces/Pain.013.001.09.ts
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { type DataCache } from './rule/DataCache';
+
 export interface Pain013 {
   TxTp: string;
   CdtrPmtActvtnReq: CdtrPmtActvtnReq;
   _key?: string;
+  DataCache?: DataCache;
 }
 
 interface CdtrPmtActvtnReq {


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

In Relation: https://github.com/frmscoe/frms-coe-lib/issues/132

## What did we change?

We added the cache object to the Transaction Interfaces. 

## Why are we doing this?

So that when the transaction gets saved and retrieved from arango, the datacache is present for lookup purposes.

## How was it tested?
- [X] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [X] Husky successfully run
- [X] Unit tests passing and Documentation done