### PR TITLE
ci: automated propagation of version bumps

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,228 @@
+name: Update FRMS COE Lib Dependencies
+
+on:
+  workflow_dispatch:
+    inputs:
+      repositories:
+        description: 'Comma-separated list of repositories to update (e.g., tazama-lf/repo1,tazama-lf/repo2)'
+        required: true
+        type: string
+      target_branch:
+        description: 'Base branch to merge updates into (default: dev)'
+        required: false
+        default: 'dev'
+        type: string
+      create_pr:
+        description: 'Create pull request for changes'
+        required: false
+        default: true
+        type: boolean
+      use_cross_org_token:
+        description: 'Use CROSS_ORG_TOKEN for private/cross-org repositories'
+        required: false
+        default: false
+        type: boolean
+  
+  # Trigger on push to main branches
+  push:
+    branches: [dev, main]
+    paths: 
+      - 'package.json'
+      - 'VERSION'
+  
+  # Optional: Trigger on release
+  release:
+    types: [published]
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout current repository
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        
+    - name: Get current package version
+      id: get_version
+      run: |
+        CURRENT_VERSION=$(node -p "require('./package.json').version")
+        PACKAGE_NAME=$(node -p "require('./package.json').name")
+        echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+        echo "package_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+        echo "Current version: $CURRENT_VERSION"
+        echo "Package name: $PACKAGE_NAME"
+    
+    - name: Set repository list
+      id: set_repos
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          REPOS="${{ github.event.inputs.repositories }}"
+        else
+          # Default repositories to update on release (from repositories.conf GITHUB_ACTION_DEFAULT)
+          REPOS="tazama-lf/frms-coe-startup-lib,tazama-lf/auth-lib,tazama-lf/tms-service,tazama-lf/admin-service,tazama-lf/auth-service,tazama-lf/event-director,tazama-lf/event-flow,tazama-lf/rule-executer,tazama-lf/rule-901,tazama-lf/typology-processor,tazama-lf/transaction-aggregation-decisioning-processor,tazama-lf/batch-ppa,tazama-lf/relay-service,tazama-lf/relay-service-integration-nats,tazama-lf/relay-service-integration-kafka,tazama-lf/relay-service-integration-rabbitmq,tazama-lf/relay-service-integration-rest,tazama-lf/nats-utilities,tazama-lf/event-sidecar,tazama-lf/lumberjack,frmscoe/rule-001,frmscoe/rule-002,frmscoe/rule-003,frmscoe/rule-004,frmscoe/rule-006,frmscoe/rule-007,frmscoe/rule-008,frmscoe/rule-010,frmscoe/rule-011,frmscoe/rule-016,frmscoe/rule-017,frmscoe/rule-018,frmscoe/rule-020,frmscoe/rule-021,frmscoe/rule-024,frmscoe/rule-025,frmscoe/rule-026,frmscoe/rule-027,frmscoe/rule-028,frmscoe/rule-030,frmscoe/rule-044,frmscoe/rule-045,frmscoe/rule-048,frmscoe/rule-054,frmscoe/rule-063,frmscoe/rule-074,frmscoe/rule-075,frmscoe/rule-076,frmscoe/rule-078,frmscoe/rule-083,frmscoe/rule-084,frmscoe/rule-090,frmscoe/rule-091"
+        fi
+        echo "repositories=$REPOS" >> $GITHUB_OUTPUT
+        echo "Will update repositories: $REPOS"
+        
+    - name: Set target branch
+      id: set_branch
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          BRANCH="${{ github.event.inputs.target_branch }}"
+        else
+          BRANCH="dev"
+        fi
+        echo "target_branch=$BRANCH" >> $GITHUB_OUTPUT
+        echo "Target branch: $BRANCH"
+
+    - name: Update dependencies in target repositories
+      env:
+        GH_TOKEN: ${{ (github.event.inputs.use_cross_org_token == 'true' && secrets.CROSS_ORG_TOKEN) || secrets.GITHUB_TOKEN }}
+        CURRENT_VERSION: ${{ steps.get_version.outputs.version }}
+        PACKAGE_NAME: ${{ steps.get_version.outputs.package_name }}
+        TARGET_BRANCH: ${{ steps.set_branch.outputs.target_branch }}
+        CREATE_PR: ${{ github.event.inputs.create_pr || 'true' }}
+      run: |
+        # Convert comma-separated repos to array
+        IFS=',' read -ra REPO_ARRAY <<< "${{ steps.set_repos.outputs.repositories }}"
+        
+        for repo in "${REPO_ARRAY[@]}"; do
+          repo=$(echo "$repo" | xargs) # trim whitespace
+          echo "Processing repository: $repo"
+          
+          # Create a temporary directory for each repo
+          TEMP_DIR=$(mktemp -d)
+          cd "$TEMP_DIR"
+          
+          # Clone the target repository with authentication
+          echo "Cloning $repo..."
+          if ! git clone "https://$GH_TOKEN@github.com/$repo.git" repo-clone 2>/dev/null; then
+            echo "Failed to clone $repo (check permissions), skipping..."
+            cd - > /dev/null
+            continue
+          fi
+          
+          cd repo-clone
+          
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Checkout base branch (where we'll merge the PR into)
+          if ! git checkout "$TARGET_BRANCH"; then
+            echo "Failed to checkout base branch $TARGET_BRANCH in $repo, skipping..."
+            cd - > /dev/null
+            continue
+          fi
+          
+          # Check if package.json exists
+          if [ ! -f "package.json" ]; then
+            echo "No package.json found in $repo, skipping..."
+            cd - > /dev/null
+            continue
+          fi
+          
+          # Check if the dependency exists
+          if ! node -p "require('./package.json').dependencies && require('./package.json').dependencies['$PACKAGE_NAME']" 2>/dev/null | grep -v undefined > /dev/null; then
+            if ! node -p "require('./package.json').devDependencies && require('./package.json').devDependencies['$PACKAGE_NAME']" 2>/dev/null | grep -v undefined > /dev/null; then
+              echo "Package $PACKAGE_NAME not found in dependencies or devDependencies of $repo, skipping..."
+              cd - > /dev/null
+              continue
+            fi
+          fi
+          
+          # Get current version in target repo
+          CURRENT_TARGET_VERSION=""
+          if node -p "require('./package.json').dependencies && require('./package.json').dependencies['$PACKAGE_NAME']" 2>/dev/null | grep -v undefined > /dev/null; then
+            CURRENT_TARGET_VERSION=$(node -p "require('./package.json').dependencies['$PACKAGE_NAME']" 2>/dev/null || echo "")
+            DEP_TYPE="dependencies"
+          elif node -p "require('./package.json').devDependencies && require('./package.json').devDependencies['$PACKAGE_NAME']" 2>/dev/null | grep -v undefined > /dev/null; then
+            CURRENT_TARGET_VERSION=$(node -p "require('./package.json').devDependencies['$PACKAGE_NAME']" 2>/dev/null || echo "")
+            DEP_TYPE="devDependencies"
+          fi
+          
+          echo "Current version in $repo: $CURRENT_TARGET_VERSION"
+          echo "New version: ^$CURRENT_VERSION"
+          
+          # Skip if versions are the same
+          if [ "$CURRENT_TARGET_VERSION" = "^$CURRENT_VERSION" ] || [ "$CURRENT_TARGET_VERSION" = "$CURRENT_VERSION" ]; then
+            echo "Version already up to date in $repo, skipping..."
+            cd - > /dev/null
+            continue
+          fi
+          
+          # Create feature branch for our changes
+          BRANCH_NAME="update-frms-coe-lib-v$CURRENT_VERSION"
+          git checkout -b "$BRANCH_NAME"
+          
+          # Update package.json using Node.js
+          cat package.json | node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('/dev/stdin', 'utf8'));
+            const depType = '$DEP_TYPE';
+            const packageName = '$PACKAGE_NAME';
+            const newVersion = '^$CURRENT_VERSION';
+            
+            if (pkg[depType] && pkg[depType][packageName]) {
+              pkg[depType][packageName] = newVersion;
+              console.log(JSON.stringify(pkg, null, 2));
+            } else {
+              console.log(JSON.stringify(pkg, null, 2));
+            }
+          " > package.json.tmp && mv package.json.tmp package.json
+          
+          # Check if changes were made
+          if git diff --quiet package.json; then
+            echo "No changes made to package.json in $repo"
+            cd - > /dev/null
+            continue
+          fi
+          
+          # Commit changes
+          git add package.json
+          git commit -m "chore: update $PACKAGE_NAME to v$CURRENT_VERSION"
+          
+          # Push changes with authentication
+          echo "Pushing changes to $repo..."
+          git remote set-url origin "https://$GH_TOKEN@github.com/$repo.git"
+          if ! git push origin "$BRANCH_NAME" 2>/dev/null; then
+            echo "Failed to push to $repo (check write permissions), skipping..."
+            cd - > /dev/null
+            continue
+          fi
+          
+          # Create pull request if requested
+          if [ "$CREATE_PR" = "true" ]; then
+            echo "Creating pull request for $repo..."
+            
+            PR_TITLE="chore: update $PACKAGE_NAME to v$CURRENT_VERSION"
+            PR_BODY="This PR updates the $PACKAGE_NAME dependency to version $CURRENT_VERSION. Updated $PACKAGE_NAME from $CURRENT_TARGET_VERSION to ^$CURRENT_VERSION. This update was automatically generated by the frms-coe-lib update workflow."
+            
+            # Create PR: feature branch -> base branch
+            gh pr create \
+              --repo "$repo" \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY" \
+              --base "$TARGET_BRANCH" \
+              --head "$BRANCH_NAME" || echo "Failed to create PR for $repo"
+          fi
+          
+          echo "Completed processing $repo"
+          cd - > /dev/null
+        done
+        
+        echo "Dependency update workflow completed!"
+
+    - name: Summary
+      run: |
+        echo "## Dependency Update Summary" >> $GITHUB_STEP_SUMMARY
+        echo "- **Package**: ${{ steps.get_version.outputs.package_name }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Version**: ${{ steps.get_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Target Repositories**: ${{ steps.set_repos.outputs.repositories }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Target Branch**: ${{ steps.set_branch.outputs.target_branch }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Create PR**: ${{ github.event.inputs.create_pr || 'true' }}" >> $GITHUB_STEP_SUMMARY

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,317 @@
+# FRMS COE Lib Dependency Update Tools
+
+This directory contains tools for automatically updating the `@tazama-lf/frms-coe-lib` dependency version in other repositories.
+
+## Files
+
+- **`update-dependencies.yml`** - GitHub Action workflow for automated updates
+- **`update-dependencies.sh`** - Bash script for local/manual updates (Linux/macOS)
+- **`update-dependencies.ps1`** - PowerShell script for local/manual updates (Windows)
+
+## GitHub Action Workflow
+
+### Triggers
+
+The workflow can be triggered in two ways:
+
+1. **Manual dispatch** - Run on-demand with custom parameters
+2. **Automatic on release** - Runs automatically when a new release is published
+
+### Manual Usage
+
+1. Go to the Actions tab in the GitHub repository
+2. Select "Update FRMS COE Lib Dependencies"
+3. Click "Run workflow"
+4. Fill in the parameters:
+   - **Repositories**: Comma-separated list of repositories to update (e.g., `tazama-lf/tms-service,tazama-lf/event-director`)
+   - **Target branch**: Branch to update (default: `dev`)
+   - **Create PR**: Whether to create pull requests for changes (default: `true`)
+
+### Automatic Usage
+
+The workflow will automatically run when a new release is published, updating a predefined list of repositories. To customize this list, edit the workflow file and modify the `REPOS` variable in the "Set repository list" step.
+
+### Required Permissions
+
+The GitHub Action requires the following permissions:
+- `contents: read` - To read the current repository
+- `pull-requests: write` - To create pull requests
+- `repository-projects: write` - To push to other repositories
+
+Make sure the `GH_TOKEN` has access to the target repositories.
+
+## Cross-Organization & Private Repository Support
+
+### 🔐 Authentication Considerations
+
+The default `GH_TOKEN` has limitations when working with repositories outside the current organization:
+
+- ✅ **Same organization, public repos**: Works with default `GH_TOKEN`
+- ❌ **Different organizations**: Requires Personal Access Token (PAT) or GitHub App
+- ❌ **Private repositories**: Requires explicit access permissions
+
+### 🔧 Setup for Cross-Organization Updates
+
+#### Option 1: Personal Access Token (Recommended for small scale)
+
+1. **Create PAT**:
+   - Go to GitHub → Settings → Developer settings → Personal access tokens
+   - Create **Classic Token** with `repo` scope
+   - Token owner must have access to all target repositories
+
+2. **Add Repository Secret**:
+   - Repository Settings → Secrets and variables → Actions
+   - Add secret: `CROSS_ORG_TOKEN` with your PAT value
+
+3. **Grant Organization Access**:
+   - For each target organization: Settings → Third-party access
+   - Approve the token for organization access
+
+#### Option 2: GitHub App (Recommended for enterprise)
+
+Create a GitHub App with repository permissions and install across organizations.
+
+### 🚀 Usage with Cross-Organization Support
+
+The GitHub Action includes a new parameter for cross-organization updates:
+
+```yaml
+# For different organizations or private repos
+repositories: "other-org/private-repo1,another-org/repo2"
+use_cross_org_token: true  # Uses CROSS_ORG_TOKEN secret
+```
+
+```yaml
+# For same organization (public repos)
+repositories: "tazama-lf/repo1,tazama-lf/repo2"
+use_cross_org_token: false  # Uses default GH_TOKEN
+```
+
+### ⚠️ Important Limitations
+
+#### Repository Access
+- Token owner must be **collaborator** on each target repository
+- Or have **organization membership** with appropriate permissions
+- **Private repositories** require explicit access grants
+
+#### Organization Policies
+Many organizations restrict:
+- External tokens entirely
+- Require GitHub Apps instead of PATs
+- Mandate specific authentication flows
+- Block cross-organization integrations
+
+#### Branch Protection Rules
+Protected branches may:
+- Prevent direct pushes (even with valid tokens)
+- Require pull request reviews before merging
+- Require status checks to pass
+
+### 🔍 Error Messages & Troubleshooting
+
+The workflow provides specific error messages for permission issues:
+
+- `"Failed to clone (check permissions)"` → Token lacks **read access**
+- `"Failed to push (check write permissions)"` → Token lacks **write access**  
+- `"Failed to create PR"` → Token lacks **PR creation** permissions
+
+### 💡 Best Practices for Cross-Organization Use
+
+1. **Test First**: Start with a single test repository
+2. **Minimal Permissions**: Use tokens with minimum required scope
+3. **Token Rotation**: Regularly rotate PATs for security
+4. **GitHub Apps**: Prefer GitHub Apps for enterprise scenarios
+5. **Organization Coordination**: Work with target organization admins
+6. **Documentation**: Document which organizations/repos are supported
+
+## Local Scripts
+
+### Bash Script (Linux/macOS)
+
+```bash
+# Make executable
+chmod +x scripts/update-dependencies.sh
+
+# Update single repository
+./scripts/update-dependencies.sh tazama-lf/tms-service
+
+# Update multiple repositories
+./scripts/update-dependencies.sh tazama-lf/tms-service tazama-lf/event-director
+
+# Update with specific branch
+./scripts/update-dependencies.sh -b main tazama-lf/tms-service
+
+# Dry run (show what would be updated)
+./scripts/update-dependencies.sh --dry-run tazama-lf/transaction-monitoring-service
+
+# Use specific version
+./scripts/update-dependencies.sh -v 6.0.0 tazama-lf/transaction-monitoring-service
+
+# Don't create pull requests
+./scripts/update-dependencies.sh --no-pr tazama-lf/transaction-monitoring-service
+```
+
+### PowerShell Script (Windows)
+
+```powershell
+# Update single repository
+.\scripts\update-dependencies.ps1 tazama-lf/tms-service
+
+# Update multiple repositories
+.\scripts\update-dependencies.ps1 tazama-lf/tms-service tazama-lf/event-director
+
+# Update with specific branch
+.\scripts\update-dependencies.ps1 -Branch main tazama-lf/tms-service
+
+# Dry run (show what would be updated)
+.\scripts\update-dependencies.ps1 -DryRun tazama-lf/transaction-monitoring-service
+
+# Use specific version
+.\scripts\update-dependencies.ps1 -Version 6.0.0 tazama-lf/transaction-monitoring-service
+
+# Don't create pull requests
+.\scripts\update-dependencies.ps1 -NoPR tazama-lf/transaction-monitoring-service
+```
+
+## Prerequisites
+
+All tools require the following to be installed and configured:
+
+1. **Git** - For cloning and pushing to repositories
+2. **GitHub CLI (gh)** - For creating pull requests
+3. **Node.js** - For reading package.json files
+4. **GitHub Token** - With appropriate permissions
+
+### GitHub Authentication
+
+You can authenticate in several ways:
+
+1. **GitHub CLI**: Run `gh auth login`
+2. **Environment Variable**: Set `GH_TOKEN` environment variable
+3. **Script Parameter**: Pass token directly to local scripts
+
+### Required Token Permissions
+
+The GitHub token needs the following scopes:
+- `repo` - Full repository access
+- `workflow` - For updating GitHub Actions (if needed)
+
+#### For Cross-Organization Access
+When updating repositories in different organizations or private repositories:
+
+1. **Set Environment Variable**:
+   ```bash
+   export GH_TOKEN="your_personal_access_token_here"
+   ```
+
+2. **Or pass directly to scripts**:
+   ```bash
+   # Bash
+   ./scripts/update-dependencies.sh --token your_pat_here other-org/private-repo
+   
+   # PowerShell
+   .\scripts\update-dependencies.ps1 -Token your_pat_here other-org/private-repo
+   ```
+
+3. **Token Requirements**:
+   - Must have `repo` scope for target repositories
+   - Token owner must have collaborator access or organization membership
+   - May need approval from organization administrators
+
+## How It Works
+
+1. **Version Detection**: Reads the current version from this repository's `package.json`
+2. **Repository Processing**: For each target repository:
+   - Clones the repository
+   - Checks out the target branch
+   - Looks for `@tazama-lf/frms-coe-lib` in `dependencies` or `devDependencies`
+   - Updates the version if different from current
+   - Commits and pushes changes to a new branch
+   - Creates a pull request (if enabled)
+
+## Customization
+
+### Default Repository List
+
+To change the default repositories updated on release, edit the workflow file:
+
+```yaml
+# Default repositories to update on release (customize this list)
+REPOS="tazama-lf/transaction-monitoring-service,tazama-lf/rule-processor,tazama-lf/typology-processor"
+```
+
+### Branch Strategy
+
+The tools create branches named `update-frms-coe-lib-v{VERSION}` (e.g., `update-frms-coe-lib-v6.0.0-rc.9`).
+
+### Pull Request Template
+
+The tools create pull requests with:
+- **Title**: `chore: update @tazama-lf/frms-coe-lib to v{VERSION}`
+- **Body**: Includes change summary and notes
+- **Labels**: None (can be customized)
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Authentication Failed**
+   - Ensure GitHub token has correct permissions
+   - For CLI: Run `gh auth login`
+   - For scripts: Set `GH_TOKEN` environment variable
+
+2. **Repository Access Denied**
+   - Token must have access to target repositories
+   - Organization repositories may require additional permissions
+
+3. **Branch Already Exists**
+   - The update branch already exists in the target repository
+   - Delete the branch or use the `--force` option
+
+4. **No Changes Made**
+   - The dependency version is already up to date
+   - Use `--force` to update anyway
+
+### Debug Mode
+
+For local scripts, use the `--dry-run` option to see what would be updated without making actual changes.
+
+## Examples
+
+### Typical Workflow
+
+1. **After publishing a new version**:
+   ```bash
+   # GitHub Action will run automatically
+   # Or manually trigger with specific repositories
+   ```
+
+2. **Before a major release**:
+   ```bash
+   # Test with dry run first
+   ./scripts/update-dependencies.sh --dry-run tazama-lf/tms-service
+   
+   # Update staging repositories to dev branch (default)
+   ./scripts/update-dependencies.sh tazama-lf/tms-service tazama-lf/event-director
+   ```
+
+3. **Emergency update**:
+   ```bash
+   # Force update even if version appears current
+   ./scripts/update-dependencies.sh --force tazama-lf/tms-service
+   ```
+
+### Repository Lists
+
+Common repository groupings (from repositories.conf):
+
+```bash
+# Core Tazama services
+CORE_REPOS="tazama-lf/tms-service,tazama-lf/event-director,tazama-lf/typology-processor"
+
+# All rule processors
+RULE_REPOS="frmscoe/rule-001,frmscoe/rule-002,frmscoe/rule-003"
+
+# Update core services
+./scripts/update-dependencies.sh $CORE_REPOS
+```

--- a/scripts/repositories.conf
+++ b/scripts/repositories.conf
@@ -1,0 +1,87 @@
+# Repository Configuration for FRMS COE Lib Updates
+# This file contains predefined repository lists for easy updates
+
+# Core Tazama libraries that use frms-coe-lib
+LIBRARY_REPOSITORIES=(
+    "tazama-lf/frms-coe-startup-lib"
+    "tazama-lf/auth-lib"
+)
+
+# Core Tazama services that commonly use frms-coe-lib
+CORE_REPOSITORIES=(
+    "tazama-lf/tms-service"
+    "tazama-lf/admin-service" 
+    "tazama-lf/auth-service" 
+    "tazama-lf/event-director" 
+    "tazama-lf/event-flow" 
+    "tazama-lf/rule-executer" 
+    "tazama-lf/rule-901"
+    "tazama-lf/typology-processor"
+    "tazama-lf/transaction-aggregation-decisioning-processor"
+)
+
+# Ancillary Tazama services that commonly use frms-coe-lib
+ANCILLARY_REPOSITORIES=(
+    "tazama-lf/batch-ppa"
+    "tazama-lf/relay-service" 
+    "tazama-lf/relay-service-integration-nats" 
+    "tazama-lf/relay-service-integration-kafka" 
+    "tazama-lf/relay-service-integration-rabbitmq" 
+    "tazama-lf/relay-service-integration-rest" 
+    "tazama-lf/nats-utilities" 
+    "tazama-lf/event-sidecar" 
+    "tazama-lf/lumberjack" 
+)
+
+# Tazama rule processors
+RULE_REPOSITORIES=(
+    "frmscoe/rule-001"
+    "frmscoe/rule-002"
+    "frmscoe/rule-003"
+    "frmscoe/rule-004"
+    "frmscoe/rule-006"
+    "frmscoe/rule-007"
+    "frmscoe/rule-008"
+    "frmscoe/rule-010"
+    "frmscoe/rule-011"
+    "frmscoe/rule-016"
+    "frmscoe/rule-017"
+    "frmscoe/rule-018"
+    "frmscoe/rule-020"
+    "frmscoe/rule-021"
+    "frmscoe/rule-024"
+    "frmscoe/rule-025"
+    "frmscoe/rule-026"
+    "frmscoe/rule-027"
+    "frmscoe/rule-028"
+    "frmscoe/rule-030"
+    "frmscoe/rule-044"
+    "frmscoe/rule-045"
+    "frmscoe/rule-048"
+    "frmscoe/rule-054"
+    "frmscoe/rule-063"
+    "frmscoe/rule-074"
+    "frmscoe/rule-075"
+    "frmscoe/rule-076"
+    "frmscoe/rule-078"
+    "frmscoe/rule-083"
+    "frmscoe/rule-084"
+    "frmscoe/rule-090"
+    "frmscoe/rule-091"
+)
+
+# All repositories (combine all above)
+ALL_REPOSITORIES=(
+    "${LIBRARY_REPOSITORIES[@]}"
+    "${CORE_REPOSITORIES[@]}"
+    "${ANCILLARY_REPOSITORIES[@]}"
+    "${RULE_REPOSITORIES[@]}"
+)
+
+# Example usage in scripts:
+# For bash: source this file, then use ${CORE_REPOSITORIES[@]}
+# For PowerShell: manually copy the repository names
+
+# GitHub Action workflow default repositories
+# Update the workflow file with this list:
+GITHUB_ACTION_DEFAULT="tazama-lf/frms-coe-startup-lib,tazama-lf/auth-lib,tazama-lf/tms-service,tazama-lf/admin-service,tazama-lf/auth-service,tazama-lf/event-director,tazama-lf/event-flow,tazama-lf/rule-executer,tazama-lf/rule-901,tazama-lf/typology-processor,tazama-lf/transaction-aggregation-decisioning-processor,tazama-lf/batch-ppa,tazama-lf/relay-service,tazama-lf/relay-service-integration-nats,tazama-lf/relay-service-integration-kafka,tazama-lf/relay-service-integration-rabbitmq,tazama-lf/relay-service-integration-rest,tazama-lf/nats-utilities,tazama-lf/event-sidecar,tazama-lf/lumberjack,frmscoe/rule-001,frmscoe/rule-002,frmscoe/rule-003,frmscoe/rule-004,frmscoe/rule-006,frmscoe/rule-007,frmscoe/rule-008,frmscoe/rule-010,frmscoe/rule-011,frmscoe/rule-016,frmscoe/rule-017,frmscoe/rule-018,frmscoe/rule-020,frmscoe/rule-021,frmscoe/rule-024,frmscoe/rule-025,frmscoe/rule-026,frmscoe/rule-027,frmscoe/rule-028,frmscoe/rule-030,frmscoe/rule-044,frmscoe/rule-045,frmscoe/rule-048,frmscoe/rule-054,frmscoe/rule-063,frmscoe/rule-074,frmscoe/rule-075,frmscoe/rule-076,frmscoe/rule-078,frmscoe/rule-083,frmscoe/rule-084,frmscoe/rule-090,frmscoe/rule-091"

--- a/scripts/update-dependencies.ps1
+++ b/scripts/update-dependencies.ps1
@@ -1,0 +1,352 @@
+# Update FRMS COE Lib Dependencies Script (PowerShell)
+# This script updates the @tazama-lf/frms-coe-lib dependency in specified repositories
+
+param(
+    [Parameter(Mandatory=$true, Position=0, ValueFromRemainingArguments=$true)]
+    [string[]]$Repositories,
+    
+    [Alias("b")]
+    [string]$Branch = "dev",
+    
+    [Alias("p")]
+    [switch]$NoPR,
+    
+    [Alias("d")]
+    [switch]$DryRun,
+    
+    [Alias("v")]
+    [string]$Version,
+    
+    [Alias("f")]
+    [switch]$Force,
+    
+    [string]$Token = $env:GH_TOKEN,
+    
+    [Alias("h")]
+    [switch]$Help
+)
+
+function Show-Help {
+    @"
+Update FRMS COE Lib Dependencies Script (PowerShell)
+
+USAGE:
+    .\update-dependencies.ps1 [OPTIONS] REPOSITORY...
+
+DESCRIPTION:
+    Updates the @tazama-lf/frms-coe-lib dependency version in specified repositories
+    to match the current version in this repository's package.json.
+
+OPTIONS:
+    -Branch, -b BRANCH      Target branch to update (default: dev)
+    -NoPR, -p              Don't create pull requests (default: create PR)
+    -DryRun, -d            Show what would be done without making changes
+    -Version, -v VERSION   Use specific version instead of current package.json version
+    -Force, -f             Force update even if version appears to be the same
+    -Token TOKEN           GitHub token (can also use GH_TOKEN env var)
+    -Help, -h              Show this help message
+
+ARGUMENTS:
+    REPOSITORY             One or more repositories in format 'owner/repo'
+
+EXAMPLES:
+    # Update single repository
+    .\update-dependencies.ps1 tazama-lf/tms-service
+
+    # Update multiple Tazama repositories
+    .\update-dependencies.ps1 tazama-lf/tms-service tazama-lf/event-director tazama-lf/typology-processor
+
+    # Update with specific branch
+    .\update-dependencies.ps1 -Branch main tazama-lf/tms-service
+
+    # Dry run to see what would be updated
+    .\update-dependencies.ps1 -DryRun tazama-lf/transaction-monitoring-service
+
+    # Use specific version
+    .\update-dependencies.ps1 -Version 6.0.0 tazama-lf/transaction-monitoring-service
+
+REQUIREMENTS:
+    - git
+    - gh (GitHub CLI)
+    - node/npm
+    - Valid GitHub token with repo access
+"@
+}
+
+function Write-LogInfo {
+    param([string]$Message)
+    Write-Host "[INFO] $Message" -ForegroundColor Blue
+}
+
+function Write-LogSuccess {
+    param([string]$Message)
+    Write-Host "[SUCCESS] $Message" -ForegroundColor Green
+}
+
+function Write-LogWarning {
+    param([string]$Message)
+    Write-Host "[WARNING] $Message" -ForegroundColor Yellow
+}
+
+function Write-LogError {
+    param([string]$Message)
+    Write-Host "[ERROR] $Message" -ForegroundColor Red
+}
+
+# Show help if requested
+if ($Help) {
+    Show-Help
+    exit 0
+}
+
+# Validate requirements
+$commands = @('git', 'gh', 'node')
+foreach ($cmd in $commands) {
+    if (!(Get-Command $cmd -ErrorAction SilentlyContinue)) {
+        Write-LogError "$cmd is required but not found in PATH"
+        exit 1
+    }
+}
+
+if ($Repositories.Count -eq 0) {
+    Write-LogError "At least one repository must be specified"
+    Show-Help
+    exit 1
+}
+
+# Check GitHub authentication
+if (-not $Token) {
+    try {
+        & gh auth status *>$null
+        if ($LASTEXITCODE -ne 0) {
+            throw "GitHub CLI not authenticated"
+        }
+    }
+    catch {
+        Write-LogError "GitHub authentication required. Please run 'gh auth login' or set GH_TOKEN"
+        exit 1
+    }
+}
+else {
+    $env:GH_TOKEN = $Token
+}
+
+# Get package information
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+$PackageJsonPath = Join-Path $ProjectRoot "package.json"
+
+if (!(Test-Path $PackageJsonPath)) {
+    Write-LogError "package.json not found at $PackageJsonPath"
+    exit 1
+}
+
+if ($Version) {
+    $CurrentVersion = $Version
+    Write-LogInfo "Using custom version: $CurrentVersion"
+}
+else {
+    $CurrentVersion = & node -p "require('$PackageJsonPath').version"
+    Write-LogInfo "Current package version: $CurrentVersion"
+}
+
+$PackageName = & node -p "require('$PackageJsonPath').name"
+Write-LogInfo "Package name: $PackageName"
+
+# Configuration
+$CreatePR = -not $NoPR
+$TargetBranch = $Branch
+
+# Counters
+$SuccessCount = 0
+$SkipCount = 0
+$ErrorCount = 0
+
+Write-LogInfo "Starting dependency update process..."
+Write-LogInfo "Target branch: $TargetBranch"
+Write-LogInfo "Create PR: $CreatePR"
+Write-LogInfo "Dry run: $DryRun"
+
+# Process each repository
+foreach ($repo in $Repositories) {
+    Write-LogInfo "Processing repository: $repo"
+    
+    # Create temporary directory
+    $TempDir = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
+    Push-Location $TempDir
+    
+    try {
+        # Clone repository
+        Write-LogInfo "Cloning $repo..."
+        & git clone "https://github.com/$repo.git" repo-clone *>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-LogError "Failed to clone $repo"
+            $ErrorCount++
+            continue
+        }
+        
+        Set-Location repo-clone
+        
+        # Configure git
+        & git config user.name "frms-coe-lib-updater"
+        & git config user.email "noreply@tazama.org"
+        
+        # Checkout target branch
+        & git checkout $TargetBranch *>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-LogError "Failed to checkout branch $TargetBranch in $repo"
+            $ErrorCount++
+            continue
+        }
+        
+        # Check if package.json exists
+        if (!(Test-Path "package.json")) {
+            Write-LogWarning "No package.json found in $repo"
+            $SkipCount++
+            continue
+        }
+        
+        # Check dependency type and current version
+        $DepType = $null
+        $CurrentTargetVersion = $null
+        
+        # Check dependencies
+        try {
+            $deps = & node -p "JSON.stringify(require('./package.json').dependencies || {})"
+            $depsObj = $deps | ConvertFrom-Json
+            if ($depsObj.PSObject.Properties.Name -contains $PackageName) {
+                $DepType = "dependencies"
+                $CurrentTargetVersion = $depsObj.$PackageName
+            }
+        }
+        catch {}
+        
+        # Check devDependencies if not found in dependencies
+        if (-not $DepType) {
+            try {
+                $devDeps = & node -p "JSON.stringify(require('./package.json').devDependencies || {})"
+                $devDepsObj = $devDeps | ConvertFrom-Json
+                if ($devDepsObj.PSObject.Properties.Name -contains $PackageName) {
+                    $DepType = "devDependencies"
+                    $CurrentTargetVersion = $devDepsObj.$PackageName
+                }
+            }
+            catch {}
+        }
+        
+        if (-not $DepType) {
+            Write-LogWarning "Package $PackageName not found in $repo dependencies"
+            $SkipCount++
+            continue
+        }
+        
+        Write-LogInfo "Found $PackageName in $DepType : $CurrentTargetVersion"
+        
+        $NewVersion = "^$CurrentVersion"
+        
+        # Check if update is needed
+        if (($CurrentTargetVersion -eq $NewVersion) -or ($CurrentTargetVersion -eq $CurrentVersion)) {
+            if (-not $Force) {
+                Write-LogInfo "Version already up to date in $repo"
+                $SkipCount++
+                continue
+            }
+            else {
+                Write-LogInfo "Forcing update even though version appears current"
+            }
+        }
+        
+        if ($DryRun) {
+            Write-LogInfo "[DRY RUN] Would update $repo : $CurrentTargetVersion -> $NewVersion"
+            $SuccessCount++
+            continue
+        }
+        
+        # Create update branch
+        $BranchName = "update-frms-coe-lib-v$CurrentVersion"
+        & git checkout -b $BranchName *>$null
+        
+        # Update package.json using Node.js
+        $UpdateScript = @"
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const depType = '$DepType';
+const packageName = '$PackageName';
+const newVersion = '$NewVersion';
+
+if (pkg[depType] && pkg[depType][packageName]) {
+    pkg[depType][packageName] = newVersion;
+}
+fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+"@
+        
+        $UpdateScript | & node
+        
+        # Check if changes were made
+        & git diff --quiet package.json
+        if ($LASTEXITCODE -eq 0) {
+            Write-LogWarning "No changes made to package.json in $repo"
+            $SkipCount++
+            continue
+        }
+        
+        # Commit and push changes
+        & git add package.json
+        & git commit -m "chore: update $PackageName to v$CurrentVersion"
+        
+        & git push origin $BranchName *>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-LogError "Failed to push changes to $repo"
+            $ErrorCount++
+            continue
+        }
+        
+        # Create pull request
+        if ($CreatePR) {
+            $PRTitle = "chore: update $PackageName to v$CurrentVersion"
+            $PRBody = @"
+This PR updates the ``$PackageName`` dependency to version ``$CurrentVersion``.
+
+## Changes
+- Updated ``$PackageName`` from ``$CurrentTargetVersion`` to ``$NewVersion``
+
+## Notes
+- This update was automatically generated
+- Please review the changelog for any breaking changes before merging
+
+---
+Generated by frms-coe-lib dependency updater (PowerShell)
+"@
+            
+            & gh pr create --repo $repo --title $PRTitle --body $PRBody --base $TargetBranch --head $BranchName *>$null
+            if ($LASTEXITCODE -eq 0) {
+                Write-LogSuccess "Created PR for $repo"
+            }
+            else {
+                Write-LogWarning "Failed to create PR for $repo (changes pushed to branch $BranchName)"
+            }
+        }
+        
+        Write-LogSuccess "Updated $repo : $CurrentTargetVersion -> $NewVersion"
+        $SuccessCount++
+    }
+    catch {
+        Write-LogError "Unexpected error processing $repo : $_"
+        $ErrorCount++
+    }
+    finally {
+        Pop-Location
+        Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Summary
+Write-Host ""
+Write-LogInfo "Update process completed!"
+Write-LogSuccess "Successfully updated: $SuccessCount repositories"
+Write-LogWarning "Skipped: $SkipCount repositories"
+Write-LogError "Errors: $ErrorCount repositories"
+
+if ($ErrorCount -gt 0) {
+    exit 1
+}

--- a/scripts/update-dependencies.sh
+++ b/scripts/update-dependencies.sh
@@ -1,0 +1,346 @@
+#!/bin/bash
+
+# Update FRMS COE Lib Dependencies Script
+# This script updates the @tazama-lf/frms-coe-lib dependency in specified repositories
+
+set -e
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PACKAGE_JSON="$PROJECT_ROOT/package.json"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+show_help() {
+    cat << EOF
+Update FRMS COE Lib Dependencies Script
+
+USAGE:
+    $0 [OPTIONS] REPOSITORY...
+
+DESCRIPTION:
+    Updates the @tazama-lf/frms-coe-lib dependency version in specified repositories
+    to match the current version in this repository's package.json.
+
+OPTIONS:
+    -h, --help             Show this help message
+    -b, --branch BRANCH    Target branch to update (default: dev)
+    -p, --no-pr            Don't create pull requests (default: create PR)
+    -d, --dry-run          Show what would be done without making changes
+    -v, --version VERSION  Use specific version instead of current package.json version
+    -f, --force            Force update even if version appears to be the same
+    --token TOKEN          GitHub token (can also use GH_TOKEN env var)
+
+ARGUMENTS:
+    REPOSITORY             One or more repositories in format 'owner/repo'
+
+EXAMPLES:
+    # Update single repository
+    $0 tazama-lf/tms-service
+
+    # Update multiple Tazama repositories
+    $0 tazama-lf/tms-service tazama-lf/event-director tazama-lf/typology-processor
+
+    # Update with specific branch
+    $0 -b main tazama-lf/tms-service
+
+    # Dry run to see what would be updated
+    $0 --dry-run tazama-lf/transaction-monitoring-service
+
+    # Use specific version
+    $0 -v 6.0.0 tazama-lf/transaction-monitoring-service
+
+REQUIREMENTS:
+    - git
+    - gh (GitHub CLI)
+    - node/npm
+    - Valid GitHub token with repo access
+
+EOF
+}
+
+# Parse command line arguments
+REPOSITORIES=()
+TARGET_BRANCH="dev"
+CREATE_PR=true
+DRY_RUN=false
+FORCE_UPDATE=false
+CUSTOM_VERSION=""
+GH_TOKEN="${GH_TOKEN:-}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        -b|--branch)
+            TARGET_BRANCH="$2"
+            shift 2
+            ;;
+        -p|--no-pr)
+            CREATE_PR=false
+            shift
+            ;;
+        -d|--dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -v|--version)
+            CUSTOM_VERSION="$2"
+            shift 2
+            ;;
+        -f|--force)
+            FORCE_UPDATE=true
+            shift
+            ;;
+        --token)
+            GH_TOKEN="$2"
+            shift 2
+            ;;
+        -*)
+            log_error "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+        *)
+            REPOSITORIES+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Validate requirements
+if ! command -v git &> /dev/null; then
+    log_error "git is required but not installed"
+    exit 1
+fi
+
+if ! command -v gh &> /dev/null; then
+    log_error "GitHub CLI (gh) is required but not installed"
+    exit 1
+fi
+
+if ! command -v node &> /dev/null; then
+    log_error "Node.js is required but not installed"
+    exit 1
+fi
+
+if [ ${#REPOSITORIES[@]} -eq 0 ]; then
+    log_error "At least one repository must be specified"
+    show_help
+    exit 1
+fi
+
+# Check GitHub token
+if [ -z "$GH_TOKEN" ]; then
+    if ! gh auth status &> /dev/null; then
+        log_error "GitHub authentication required. Please run 'gh auth login' or set GH_TOKEN"
+        exit 1
+    fi
+else
+    export GH_TOKEN
+fi
+
+# Get package information
+if [ ! -f "$PACKAGE_JSON" ]; then
+    log_error "package.json not found at $PACKAGE_JSON"
+    exit 1
+fi
+
+if [ -n "$CUSTOM_VERSION" ]; then
+    CURRENT_VERSION="$CUSTOM_VERSION"
+    log_info "Using custom version: $CURRENT_VERSION"
+else
+    CURRENT_VERSION=$(node -p "require('$PACKAGE_JSON').version")
+    log_info "Current package version: $CURRENT_VERSION"
+fi
+
+PACKAGE_NAME=$(node -p "require('$PACKAGE_JSON').name")
+log_info "Package name: $PACKAGE_NAME"
+
+# Main processing loop
+log_info "Starting dependency update process..."
+log_info "Target branch: $TARGET_BRANCH"
+log_info "Create PR: $CREATE_PR"
+log_info "Dry run: $DRY_RUN"
+
+SUCCESS_COUNT=0
+SKIP_COUNT=0
+ERROR_COUNT=0
+
+for repo in "${REPOSITORIES[@]}"; do
+    log_info "Processing repository: $repo"
+    
+    # Create temporary directory
+    TEMP_DIR=$(mktemp -d)
+    cd "$TEMP_DIR"
+    
+    # Clone repository
+    if ! git clone "https://github.com/$repo.git" repo-clone 2>/dev/null; then
+        log_error "Failed to clone $repo"
+        ((ERROR_COUNT++))
+        cd - > /dev/null
+        continue
+    fi
+    
+    cd repo-clone
+    
+    # Configure git
+    git config user.name "frms-coe-lib-updater"
+    git config user.email "noreply@tazama.org"
+    
+    # Checkout target branch
+    if ! git checkout "$TARGET_BRANCH" 2>/dev/null; then
+        log_error "Failed to checkout branch $TARGET_BRANCH in $repo"
+        ((ERROR_COUNT++))
+        cd - > /dev/null
+        continue
+    fi
+    
+    # Check if package.json exists
+    if [ ! -f "package.json" ]; then
+        log_warning "No package.json found in $repo"
+        ((SKIP_COUNT++))
+        cd - > /dev/null
+        continue
+    fi
+    
+    # Check dependency type and current version
+    DEP_TYPE=""
+    CURRENT_TARGET_VERSION=""
+    
+    if node -p "require('./package.json').dependencies && require('./package.json').dependencies['$PACKAGE_NAME']" 2>/dev/null | grep -v undefined > /dev/null; then
+        DEP_TYPE="dependencies"
+        CURRENT_TARGET_VERSION=$(node -p "require('./package.json').dependencies['$PACKAGE_NAME']" 2>/dev/null || echo "")
+    elif node -p "require('./package.json').devDependencies && require('./package.json').devDependencies['$PACKAGE_NAME']" 2>/dev/null | grep -v undefined > /dev/null; then
+        DEP_TYPE="devDependencies"
+        CURRENT_TARGET_VERSION=$(node -p "require('./package.json').devDependencies['$PACKAGE_NAME']" 2>/dev/null || echo "")
+    else
+        log_warning "Package $PACKAGE_NAME not found in $repo dependencies"
+        ((SKIP_COUNT++))
+        cd - > /dev/null
+        continue
+    fi
+    
+    log_info "Found $PACKAGE_NAME in $DEP_TYPE: $CURRENT_TARGET_VERSION"
+    
+    NEW_VERSION="^$CURRENT_VERSION"
+    
+    # Check if update is needed
+    if [ "$CURRENT_TARGET_VERSION" = "$NEW_VERSION" ] || [ "$CURRENT_TARGET_VERSION" = "$CURRENT_VERSION" ]; then
+        if [ "$FORCE_UPDATE" = false ]; then
+            log_info "Version already up to date in $repo"
+            ((SKIP_COUNT++))
+            cd - > /dev/null
+            continue
+        else
+            log_info "Forcing update even though version appears current"
+        fi
+    fi
+    
+    if [ "$DRY_RUN" = true ]; then
+        log_info "[DRY RUN] Would update $repo: $CURRENT_TARGET_VERSION -> $NEW_VERSION"
+        ((SUCCESS_COUNT++))
+        cd - > /dev/null
+        continue
+    fi
+    
+    # Create update branch
+    BRANCH_NAME="update-frms-coe-lib-v$CURRENT_VERSION"
+    git checkout -b "$BRANCH_NAME"
+    
+    # Update package.json
+    cat package.json | node -e "
+        const fs = require('fs');
+        const pkg = JSON.parse(fs.readFileSync('/dev/stdin', 'utf8'));
+        const depType = '$DEP_TYPE';
+        const packageName = '$PACKAGE_NAME';
+        const newVersion = '$NEW_VERSION';
+        
+        if (pkg[depType] && pkg[depType][packageName]) {
+            pkg[depType][packageName] = newVersion;
+        }
+        console.log(JSON.stringify(pkg, null, 2));
+    " > package.json.tmp && mv package.json.tmp package.json
+    
+    # Check if changes were made
+    if git diff --quiet package.json; then
+        log_warning "No changes made to package.json in $repo"
+        ((SKIP_COUNT++))
+        cd - > /dev/null
+        continue
+    fi
+    
+    # Commit and push changes
+    git add package.json
+    git commit -m "chore: update $PACKAGE_NAME to v$CURRENT_VERSION"
+    
+    if ! git push origin "$BRANCH_NAME" 2>/dev/null; then
+        log_error "Failed to push changes to $repo"
+        ((ERROR_COUNT++))
+        cd - > /dev/null
+        continue
+    fi
+    
+    # Create pull request
+    if [ "$CREATE_PR" = true ]; then
+        PR_TITLE="chore: update $PACKAGE_NAME to v$CURRENT_VERSION"
+        PR_BODY="This PR updates the \`$PACKAGE_NAME\` dependency to version \`$CURRENT_VERSION\`.
+
+## Changes
+- Updated \`$PACKAGE_NAME\` from \`$CURRENT_TARGET_VERSION\` to \`$NEW_VERSION\`
+
+## Notes
+- This update was automatically generated
+- Please review the changelog for any breaking changes before merging
+
+---
+Generated by frms-coe-lib dependency updater"
+        
+        if gh pr create --repo "$repo" --title "$PR_TITLE" --body "$PR_BODY" --base "$TARGET_BRANCH" --head "$BRANCH_NAME" &> /dev/null; then
+            log_success "Created PR for $repo"
+        else
+            log_warning "Failed to create PR for $repo (changes pushed to branch $BRANCH_NAME)"
+        fi
+    fi
+    
+    log_success "Updated $repo: $CURRENT_TARGET_VERSION -> $NEW_VERSION"
+    ((SUCCESS_COUNT++))
+    
+    cd - > /dev/null
+done
+
+# Summary
+echo ""
+log_info "Update process completed!"
+log_success "Successfully updated: $SUCCESS_COUNT repositories"
+log_warning "Skipped: $SKIP_COUNT repositories"
+log_error "Errors: $ERROR_COUNT repositories"
+
+if [ $ERROR_COUNT -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Added workflow to propagate an update to VERSION or package.json to all dependent Tazama repositories on push to `dev` or `main`.

## Why are we doing this?

System-wide version bumps are time-consuming and annoying.

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done