### PR TITLE
feat: Add OpenSearch-based audit logging service

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,16 +204,34 @@ export class AuditLogModule {}
 ```
 Then, import this new `AuditLogModule` into the `imports` array of your root `app.module.ts`.
 
+*How to Use*
 ```typescript
 import { AuditLogger, AuditLogData } from '@tazama-lf/frms-coe-lib';
 @Injectable()
 export class MyService {
   constructor(
     private readonly auditLoggerService: AuditLogger,
+    // other services
   ) {}
     async performAction () {
-      const logData: AuditLogData = { /* ... event data ... */ };
-      await auditLogger.log(logData);
+      // existing code
+      this.auditLoggerService.log({
+         eventType: 'Manual Case Creation',
+         actorId: '7234-4nsdj-nnmf',
+         actorRole: 'actorRole',
+         actorName: 'actorName'
+         actorEmail: 'actor@gmail.com'
+         eventType: 'update_name'
+         sourceIp: '127.0.0.1',
+         description: `Manual case created`,
+         status: 'success',
+         resourceType: 'Case',
+         resourceId: userId,
+         action_performed: { name: 'Ali' },
+         outcome: { success: true, newValue: { name: 'Ahmed' } },
+         serviceName: 'cms-backend',
+         tenantId: tenantId,
+     })
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -165,6 +165,70 @@ databaseManager = await CreateDatabaseManager(dbConfig);
 
 ```
 
+### 5. **Audit Logging**
+
+The `AuditLogger` provides a singleton service to send critical events to an OpenSearch backend. First, initialize the logger with your service name at application startup. Then, use the instance to log events from anywhere in your application.
+
+**Usage Example:**
+
+*Typescript:*
+```typescript
+import { AuditLogger, AuditLogData } from '@tazama-lf/frms-coe-lib';
+
+// 1. Initialize once at startup
+const auditLogger = AuditLogger.getInstance();
+await auditLogger.init('my-application-service');
+
+// 2. Use it anywhere to log an event
+const logData: AuditLogData = { /* ... event data ... */ };
+await auditLogger.log(logData);
+```
+*Nest JS*
+Create a new file, for example, `src/audit-log/audit-log.module.ts`:
+
+```typescript
+import { Module, Global } from '@nestjs/common';
+import { createAuditProvider } from '@tazama-lf/frms-coe-lib';
+
+@Global() // Makes the provider available everywhere
+@Module({
+  providers: [
+    // Provide the service name here
+    createAuditProvider('case-management-service'), 
+  ],
+  exports: [
+    'AUDIT_LOGGER', // Export the provider by its token
+  ],
+})
+export class AuditLogModule {}
+```
+Then, import this new `AuditLogModule` into the `imports` array of your root `app.module.ts`.
+
+```typescript
+import { AuditLogger, AuditLogData } from '@tazama-lf/frms-coe-lib';
+@Injectable()
+export class MyService {
+  constructor(
+    private readonly auditLoggerService: AuditLogger,
+  ) {}
+    async performAction () {
+      const logData: AuditLogData = { /* ... event data ... */ };
+      await auditLogger.log(logData);
+    }
+}
+```
+
+#### Configuration (Environment Variables)
+
+The library automatically reads these variables from your environment.
+
+| Variable              | Required | Default                  | Description                  |
+| --------------------- | -------- | ------------------------ | ---------------------------- |
+| `OPENSEARCH_NODE`     | Yes      | `http://localhost:9200`  | URL of the OpenSearch Cluster|
+| `OPENSEARCH_USERNAME` | No       | `admin`                  | Basic Auth Username          |
+| `OPENSEARCH_PASSWORD` | No       | `admin`                  | Basic Auth Password          |
+
+
 ## Modules and Classes
 
 1. **ProtoBuf Module**

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ export class AuditLogModule {}
 ```
 Then, import this new `AuditLogModule` into the `imports` array of your root `app.module.ts`.
 
-*How to Use*
+#### How to Use
 ```typescript
 import { AuditLogger } from '@tazama-lf/frms-coe-lib';
 @Injectable()
@@ -243,6 +243,7 @@ The library automatically reads these variables from your environment.
 | `OPENSEARCH_NODE`     | Yes      | `http://localhost:9200`  | URL of the OpenSearch Cluster|
 | `OPENSEARCH_USERNAME` | No       | `admin`                  | Basic Auth Username          |
 | `OPENSEARCH_PASSWORD` | No       | `admin`                  | Basic Auth Password          |
+| `OPENSEARCH_SSL_REJECT_UNAUTHORIZED` | No       | true                 | Reject unauthorized SSL certificates          |
 
 
 ## Modules and Classes

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Then, import this new `AuditLogModule` into the `imports` array of your root `ap
 
 *How to Use*
 ```typescript
-import { AuditLogger, AuditLogData } from '@tazama-lf/frms-coe-lib';
+import { AuditLogger } from '@tazama-lf/frms-coe-lib';
 @Injectable()
 export class MyService {
   constructor(
@@ -216,20 +216,18 @@ export class MyService {
     async performAction () {
       // existing code
       this.auditLoggerService.log({
-         eventType: 'Manual Case Creation',
-         actorId: '7234-4nsdj-nnmf',
-         actorRole: 'actorRole',
-         actorName: 'actorName'
-         actorEmail: 'actor@gmail.com'
-         eventType: 'update_name'
-         sourceIp: '127.0.0.1',
-         description: `Manual case created`,
+         eventType: 'Update User Name',
+         actorId: '7234-4nsdj-nnmf', // action performed by
+         actorRole: 'actorRole', // action performed by
+         actorName: 'actorName', // action performed by
+         actorEmail: 'actor@gmail.com', // action performed by
+         sourceIp: '127.0.0.1',// IP address
+         description: `User name updated successfully`,
          status: 'success',
-         resourceType: 'Case',
-         resourceId: userId,
-         action_performed: { name: 'Ali' },
-         outcome: { success: true, newValue: { name: 'Ahmed' } },
-         serviceName: 'cms-backend',
+         resourceType: 'Case', //action done on
+         resourceId: userId, // action done on
+         actionPerformed: { name: 'Ali' }, // optional field
+         outcome: { success: true, newValue: { name: 'Ahmed' } }, // optional field
          tenantId: tenantId,
      })
     }

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -92,3 +92,13 @@ Logging Class: This class needs configuration variables to check the environment
 | -------- | ------- | ------- | 
 | LOG_LEVEL | String | Yes | 
 | SIDECAR_HOST | String | Yes | 
+
+
+### OpenSearch Configuration
+
+| Variables | DataType | Optional | 
+| -------- | ------- | ------- | 
+| OPENSEARCH_NODE | String | No | 
+| OPENSEARCH_USERNAME | String | Yes | 
+| OPENSEARCH_PASSWORD | String | Yes | 
+| OPENSEARCH_SSL_REJECT_UNAUTHORIZED | Boolean | No | 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -99,6 +99,6 @@ Logging Class: This class needs configuration variables to check the environment
 | Variables | DataType | Optional | 
 | -------- | ------- | ------- | 
 | OPENSEARCH_NODE | String | No | 
-| OPENSEARCH_USERNAME | String | No | 
-| OPENSEARCH_PASSWORD | String | No | 
+| OPENSEARCH_USERNAME | String | Yes | 
+| OPENSEARCH_PASSWORD | String | Yes | 
 | OPENSEARCH_SSL_REJECT_UNAUTHORIZED | Boolean | No | 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -99,6 +99,6 @@ Logging Class: This class needs configuration variables to check the environment
 | Variables | DataType | Optional | 
 | -------- | ------- | ------- | 
 | OPENSEARCH_NODE | String | No | 
-| OPENSEARCH_USERNAME | String | Yes | 
-| OPENSEARCH_PASSWORD | String | Yes | 
+| OPENSEARCH_USERNAME | String | No | 
+| OPENSEARCH_PASSWORD | String | No | 
 | OPENSEARCH_SSL_REJECT_UNAUTHORIZED | Boolean | No | 

--- a/__tests__/auditLog.service.test.ts
+++ b/__tests__/auditLog.service.test.ts
@@ -5,8 +5,8 @@ import { AuditLogger } from '../src/services/auditLog.service';
 jest.mock('../src/config/openSearch.config', () => ({
   openSearchConfig: () => ({
     node: 'http://localhost:9200',
-    auth: 'test-user',
-    ssl: false,
+    auth: { username: 'test-user', password: 'test-pass' },
+    ssl: { rejectUnauthorized: false },
     indexPrefix: 'audit-logs-test',
   }),
 }));
@@ -22,7 +22,7 @@ describe('AuditLogger', () => {
     logger = AuditLogger.getInstance();
 
     mockIndex = jest.fn().mockResolvedValue({ body: { result: 'created' } });
-    mockExistsTemplate = jest.fn().mockResolvedValue({ body: false });
+    mockExistsTemplate = jest.fn().mockResolvedValue({ statusCode: 404 });
     mockPutTemplate = jest.fn().mockResolvedValue({ body: { acknowledged: true } });
 
     const mockClient = {
@@ -52,7 +52,7 @@ describe('AuditLogger', () => {
     });
 
     it('should NOT create schema if it already exists', async () => {
-      mockExistsTemplate.mockResolvedValueOnce({ body: true });
+      mockExistsTemplate.mockResolvedValueOnce({ statusCode: 200 });
       await logger.init('test-service');
       expect(mockExistsTemplate).toHaveBeenCalled();
       expect(mockPutTemplate).not.toHaveBeenCalled();

--- a/__tests__/auditLog.service.test.ts
+++ b/__tests__/auditLog.service.test.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { validateEnvVar } from '../src/config';
 import { AuditLogger } from '../src/services/auditLog.service';
 // Mock OpenSearch config to avoid env validation during service construction
 jest.mock('../src/config/openSearch.config', () => ({
@@ -76,7 +75,7 @@ describe('AuditLogger', () => {
         resourceId: 'account-55',
         resourceType: 'UserAccount',
         outcome: { extra: 'data' },
-        action_performed: { performed: 'action' },
+        actionPerformed: { performed: 'action' },
         tenantId: 'tenant-1',
       });
 
@@ -98,7 +97,7 @@ describe('AuditLogger', () => {
           resourceId: 'account-55',
           resourceType: 'UserAccount',
           outcome: { extra: 'data' },
-          action_performed: { performed: 'action' },
+          actionPerformed: { performed: 'action' },
           tenantId: 'tenant-1',
         },
       });

--- a/__tests__/auditLog.service.test.ts
+++ b/__tests__/auditLog.service.test.ts
@@ -1,3 +1,13 @@
+// Mock OpenSearch config to avoid env validation during service construction
+jest.mock('../src/config/openSearch.config', () => ({
+  openSearchConfig: () => ({
+    node: 'http://localhost:9200',
+    auth: undefined,
+    ssl: undefined,
+    indexPrefix: 'audit-logs-test',
+  }),
+}));
+
 import { AuditLogger } from '../src/services/auditLog.service';
 
 describe('AuditLogger', () => {
@@ -76,7 +86,7 @@ describe('AuditLogger', () => {
         body: {
           actorId: 'user-123',
           eventType: 'LOGIN',
-          status: 'SUCCESS',
+          status: 'success',
           description: 'User logged in',
           sourceIp: '127.0.0.1',
           serviceName: 'AuthService',
@@ -91,9 +101,6 @@ describe('AuditLogger', () => {
     });
 
     it('should throw error if OpenSearch fails', async () => {
-      // 1. Silence console.error
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
       // 2. Force Failure
       mockIndex.mockRejectedValueOnce(new Error('Connection Refused'));
 
@@ -103,16 +110,10 @@ describe('AuditLogger', () => {
           serviceName: 'test',
           actorId: '1',
           eventType: 'FAIL',
-          status: 'FAILURE',
+          status: 'failure',
           description: 'test',
         } as any),
       ).rejects.toThrow('Audit Log Failed: Transaction Aborted.');
-
-      // 4. Verify the code actually TRIED to log the error (optional but good practice)
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('CRITICAL FAIL'));
-
-      // 5. Restore console.error so other tests can print errors
-      consoleSpy.mockRestore();
     });
   });
 });

--- a/__tests__/auditLog.service.test.ts
+++ b/__tests__/auditLog.service.test.ts
@@ -1,0 +1,118 @@
+import { AuditLogger } from '../src/services/auditLog.service';
+
+describe('AuditLogger', () => {
+  let logger: AuditLogger;
+  let mockIndex: jest.Mock;
+  let mockExistsTemplate: jest.Mock;
+  let mockPutTemplate: jest.Mock;
+
+  beforeEach(async () => {
+    (AuditLogger as any).instance = undefined;
+    logger = AuditLogger.getInstance();
+
+    mockIndex = jest.fn().mockResolvedValue({ body: { result: 'created' } });
+    mockExistsTemplate = jest.fn().mockResolvedValue({ body: false });
+    mockPutTemplate = jest.fn().mockResolvedValue({ body: { acknowledged: true } });
+
+    const mockClient = {
+      index: mockIndex,
+      indices: {
+        existsTemplate: mockExistsTemplate,
+        putTemplate: mockPutTemplate,
+      },
+    };
+
+    (logger as any).client = mockClient;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('init()', () => {
+    it('should create schema if it does not exist', async () => {
+      await logger.init();
+
+      // FIX: Changed 'v2' to match the actual code
+      expect(mockExistsTemplate).toHaveBeenCalledWith({
+        name: 'audit-logs-template',
+      });
+      expect(mockPutTemplate).toHaveBeenCalled();
+    });
+
+    it('should NOT create schema if it already exists', async () => {
+      mockExistsTemplate.mockResolvedValueOnce({ body: true });
+      await logger.init();
+      expect(mockExistsTemplate).toHaveBeenCalled();
+      expect(mockPutTemplate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('log()', () => {
+    it('should send correct data to OpenSearch', async () => {
+      await logger.init();
+
+      await logger.log({
+        actorId: 'user-123',
+        eventType: 'LOGIN',
+        status: 'success',
+        description: 'User logged in',
+        sourceIp: '127.0.0.1',
+        serviceName: 'AuthService',
+        actorRole: 'Admin',
+        actorName: 'John Doe',
+        actorEmail: 'john.doe@example.com',
+        resourceId: 'account-55',
+        resourceType: 'UserAccount',
+        metadata: { extra: 'data' },
+      });
+
+      expect(mockIndex).toHaveBeenCalledTimes(1);
+
+      const callArgs = mockIndex.mock.calls[0][0];
+
+      expect(callArgs).toMatchObject({
+        refresh: 'wait_for',
+        body: {
+          actorId: 'user-123',
+          eventType: 'LOGIN',
+          status: 'SUCCESS',
+          description: 'User logged in',
+          sourceIp: '127.0.0.1',
+          serviceName: 'AuthService',
+          actorRole: 'Admin',
+          actorName: 'John Doe',
+          actorEmail: 'john.doe@example.com',
+          resourceId: 'account-55',
+          resourceType: 'UserAccount',
+          metadata: { extra: 'data' },
+        },
+      });
+    });
+
+    it('should throw error if OpenSearch fails', async () => {
+      // 1. Silence console.error
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      // 2. Force Failure
+      mockIndex.mockRejectedValueOnce(new Error('Connection Refused'));
+
+      // 3. Run Test
+      await expect(
+        logger.log({
+          serviceName: 'test',
+          actorId: '1',
+          eventType: 'FAIL',
+          status: 'FAILURE',
+          description: 'test',
+        } as any),
+      ).rejects.toThrow('Audit Log Failed: Transaction Aborted.');
+
+      // 4. Verify the code actually TRIED to log the error (optional but good practice)
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('CRITICAL FAIL'));
+
+      // 5. Restore console.error so other tests can print errors
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/__tests__/auditLog.service.test.ts
+++ b/__tests__/auditLog.service.test.ts
@@ -1,14 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { validateEnvVar } from '../src/config';
+import { AuditLogger } from '../src/services/auditLog.service';
 // Mock OpenSearch config to avoid env validation during service construction
 jest.mock('../src/config/openSearch.config', () => ({
   openSearchConfig: () => ({
-    node: 'http://localhost:9200',
-    auth: undefined,
-    ssl: undefined,
+    node: validateEnvVar('OPENSEARCH_NODE', 'string'),
+    auth: validateEnvVar('OPENSEARCH_USERNAME', 'string'),
+    ssl: validateEnvVar('OPENSEARCH_SSL_REJECT_UNAUTHORIZED', 'boolean'),
     indexPrefix: 'audit-logs-test',
   }),
 }));
-
-import { AuditLogger } from '../src/services/auditLog.service';
 
 describe('AuditLogger', () => {
   let logger: AuditLogger;
@@ -41,7 +43,7 @@ describe('AuditLogger', () => {
 
   describe('init()', () => {
     it('should create schema if it does not exist', async () => {
-      await logger.init();
+      await logger.init('test-service');
 
       // FIX: Changed 'v2' to match the actual code
       expect(mockExistsTemplate).toHaveBeenCalledWith({
@@ -52,7 +54,7 @@ describe('AuditLogger', () => {
 
     it('should NOT create schema if it already exists', async () => {
       mockExistsTemplate.mockResolvedValueOnce({ body: true });
-      await logger.init();
+      await logger.init('test-service');
       expect(mockExistsTemplate).toHaveBeenCalled();
       expect(mockPutTemplate).not.toHaveBeenCalled();
     });
@@ -60,7 +62,7 @@ describe('AuditLogger', () => {
 
   describe('log()', () => {
     it('should send correct data to OpenSearch', async () => {
-      await logger.init();
+      await logger.init('TestService');
 
       await logger.log({
         actorId: 'user-123',
@@ -68,7 +70,6 @@ describe('AuditLogger', () => {
         status: 'success',
         description: 'User logged in',
         sourceIp: '127.0.0.1',
-        serviceName: 'AuthService',
         actorRole: 'Admin',
         actorName: 'John Doe',
         actorEmail: 'john.doe@example.com',
@@ -91,7 +92,6 @@ describe('AuditLogger', () => {
           status: 'success',
           description: 'User logged in',
           sourceIp: '127.0.0.1',
-          serviceName: 'AuthService',
           actorRole: 'Admin',
           actorName: 'John Doe',
           actorEmail: 'john.doe@example.com',
@@ -111,7 +111,6 @@ describe('AuditLogger', () => {
       // 3. Run Test
       await expect(
         logger.log({
-          serviceName: 'test',
           actorId: '1',
           eventType: 'FAIL',
           status: 'failure',

--- a/__tests__/auditLog.service.test.ts
+++ b/__tests__/auditLog.service.test.ts
@@ -5,9 +5,9 @@ import { AuditLogger } from '../src/services/auditLog.service';
 // Mock OpenSearch config to avoid env validation during service construction
 jest.mock('../src/config/openSearch.config', () => ({
   openSearchConfig: () => ({
-    node: validateEnvVar('OPENSEARCH_NODE', 'string'),
-    auth: validateEnvVar('OPENSEARCH_USERNAME', 'string'),
-    ssl: validateEnvVar('OPENSEARCH_SSL_REJECT_UNAUTHORIZED', 'boolean'),
+    node: 'http://localhost:9200',
+    auth: 'test-user',
+    ssl: false,
     indexPrefix: 'audit-logs-test',
   }),
 }));

--- a/__tests__/auditLog.service.test.ts
+++ b/__tests__/auditLog.service.test.ts
@@ -74,7 +74,9 @@ describe('AuditLogger', () => {
         actorEmail: 'john.doe@example.com',
         resourceId: 'account-55',
         resourceType: 'UserAccount',
-        metadata: { extra: 'data' },
+        outcome: { extra: 'data' },
+        action_performed: { performed: 'action' },
+        tenantId: 'tenant-1',
       });
 
       expect(mockIndex).toHaveBeenCalledTimes(1);
@@ -95,7 +97,9 @@ describe('AuditLogger', () => {
           actorEmail: 'john.doe@example.com',
           resourceId: 'account-55',
           resourceType: 'UserAccount',
-          metadata: { extra: 'data' },
+          outcome: { extra: 'data' },
+          action_performed: { performed: 'action' },
+          tenantId: 'tenant-1',
         },
       });
     });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,70 @@
+services:
+  opensearch-node1: # This is also the hostname of the container within the Docker network (i.e. https://opensearch-node1/)
+    image: opensearchproject/opensearch:latest # Specifying the latest available image - modify if you want a specific version
+    container_name: opensearch-node1
+    environment:
+      - cluster.name=opensearch-cluster # Name the cluster
+      - node.name=opensearch-node1 # Name the node that will run in this container
+      - discovery.seed_hosts=opensearch-node1,opensearch-node2 # Nodes to look for when discovering the cluster
+      - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2 # Nodes eligible to serve as cluster manager
+      - bootstrap.memory_lock=true # Disable JVM heap memory swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # Set min and max JVM heap sizes to at least 50% of system RAM
+      - DISABLE_SECURITY_PLUGIN=true # Disable the security plugin for testing purposes only
+      # - OPENSEARCH_INITIAL_ADMIN_PASSWORD=OpenSearchAdmin123@  # Sets the demo admin user password when using demo configuration, required for OpenSearch 2.12 and later
+    ulimits:
+      memlock:
+        soft: -1 # Set memlock to unlimited (no soft or hard limit)
+        hard: -1
+      nofile:
+        soft: 65536 # Maximum number of open files for the opensearch user - set to at least 65536
+        hard: 65536
+    volumes:
+      - opensearch-data1:/usr/share/opensearch/data # Creates volume called opensearch-data1 and mounts it to the container
+    ports:
+      - 9200:9200 # REST API
+      - 9600:9600 # Performance Analyzer
+    networks:
+      - opensearch-net # All of the containers will join the same Docker bridge network
+  opensearch-node2:
+    image: opensearchproject/opensearch:latest # This should be the same image used for opensearch-node1 to avoid issues
+    container_name: opensearch-node2
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=opensearch-node2
+      - discovery.seed_hosts=opensearch-node1,opensearch-node2
+      - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - DISABLE_SECURITY_PLUGIN=true
+      # - OPENSEARCH_INITIAL_ADMIN_PASSWORD=OpenSearchAdmin123@
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - opensearch-data2:/usr/share/opensearch/data
+    networks:
+      - opensearch-net
+  opensearch-dashboards:
+    image: opensearchproject/opensearch-dashboards:latest # Make sure the version of opensearch-dashboards matches the version of opensearch installed on other nodes
+    container_name: opensearch-dashboards
+    ports:
+      - 5601:5601 # Map host port 5601 to container port 5601
+    expose:
+      - "5601" # Expose port 5601 for web access to OpenSearch Dashboards
+    environment:
+      # OPENSEARCH_HOSTS: '["https://opensearch-node1:9200","https://opensearch-node2:9200"]' # Define the OpenSearch nodes that OpenSearch Dashboards will query
+      OPENSEARCH_HOSTS: '["http://opensearch-node1:9200","http://opensearch-node2:9200"]' # Define the OpenSearch nodes that OpenSearch Dashboards will query
+      DISABLE_SECURITY_DASHBOARDS_PLUGIN: "true"
+    networks:
+      - opensearch-net
+
+volumes:
+  opensearch-data1:
+  opensearch-data2:
+
+networks:
+  opensearch-net:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@elastic/ecs-pino-format": "^1.5.0",
         "@grpc/grpc-js": "^1.13.4",
         "@grpc/proto-loader": "~0.7.15",
+        "@opensearch-project/opensearch": "^3.5.1",
         "@types/pg": "^8.15.5",
         "@types/uuid": "^10.0.0",
         "dotenv": "^17.2.1",
@@ -633,9 +634,9 @@
       }
     },
     "node_modules/@elastic/transport": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.10.0.tgz",
-      "integrity": "sha512-Xd62ZtgdrJuaunTLk0LqYtkUtJ3D2/NQ4QyLWPYj0c2h97SNUaNkrQH9lzb6r2P0Bdjx/HwKtW3X8kO5LJ7qEQ==",
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.10.1.tgz",
+      "integrity": "sha512-xo2lPBAJEt81fQRAKa9T/gUq1SPGBHpSnVUXhoSpL996fPZRAfQwFA4BZtEUQL1p8Dezodd3ZN8Wwno+mYyKuw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.x",
@@ -652,9 +653,9 @@
       }
     },
     "node_modules/@elastic/transport/node_modules/@opentelemetry/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-PcmxJQzs31cfD0R2dE91YGFcLxOSN4Bxz7gez5UwSUjCai8BwH/GI5HchfVshHkWdTkUs0qcaPJgVHKXUp7I3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -667,18 +668,34 @@
       }
     },
     "node_modules/@elastic/transport/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
-      "integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
+      "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
     },
+    "node_modules/@elastic/transport/node_modules/secure-json-parse": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-3.0.2.tgz",
+      "integrity": "sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@emnapi/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-zq/ay+9fNIJJtJiZxdTnXS20PllcYMX3OE23ESc4HK/bdYu3cOWYVhsOhVnXALfU/uqJIxn5NBPd9z4v+SfoSg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -688,9 +705,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.6.0.tgz",
-      "integrity": "sha512-obtUmAHTMjll499P+D9A3axeJFlhdjOWdKUNs/U6QIGT7V5RjcUW1xToAzjvmgTSQhDbYn/NwfTRoJcQ2rNBxA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -730,9 +747,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -837,9 +854,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -849,7 +866,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
@@ -871,6 +888,37 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -885,9 +933,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.0.tgz",
-      "integrity": "sha512-BIhe0sW91JGPiaF1mOuPy5v8NflqfjIcDNpC+LbW9f609WVRX1rArrhi6Z2ymvrAry9jw+5POTj4t2t62o8Bmw==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -922,9 +970,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.0.tgz",
-      "integrity": "sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
@@ -1030,9 +1078,9 @@
       "license": "MIT"
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.4.0.tgz",
-      "integrity": "sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
+      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
       "license": "MIT"
     },
     "node_modules/@isaacs/balanced-match": {
@@ -1118,9 +1166,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1615,42 +1663,22 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
+    "node_modules/@opensearch-project/opensearch": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch/-/opensearch-3.5.1.tgz",
+      "integrity": "sha512-6bf+HcuERzAtHZxrm6phjref54ABse39BpkDie/YO3AUFMCBrb3SK5okKSdT5n3+nDRuEEQLhQCl0RQV3s1qpA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
+        "aws4": "^1.11.0",
+        "debug": "^4.3.1",
+        "hpagent": "^1.2.0",
+        "json11": "^2.0.0",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^2.4.0"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
+        "node": ">=14",
+        "yarn": "^1.22.10"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -1821,9 +1849,9 @@
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.41",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
-      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "version": "0.34.47",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.47.tgz",
+      "integrity": "sha512-ZGIBQ+XDvO5JQku9wmwtabcVTHJsgSWAHYtVuM9pBNNR5E88v6Jcj/llpmsjivig5X8A8HHOb4/mbEKPS5EvAw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1848,16 +1876,16 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.5.0.tgz",
-      "integrity": "sha512-IeZF+8H0ns6prg4VrkhgL+yrvDXWDH2cKchrbh80ejG9dQgZWp10epHMbgRuQvgchLII/lfh6Xn3lu6+6L86Hw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.7.0.tgz",
+      "integrity": "sha512-PsSugIf9ip1H/mWKj4bi/BlEoerxXAda9ByRFsYuwsmr6af9NxJL0AaiNXs8Le7R21QR5KMiD/KdxZZ71LjAxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.0",
-        "@typescript-eslint/types": "^8.46.1",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.52.0",
+        "eslint-visitor-keys": "^5.0.0",
+        "espree": "^11.0.0",
         "estraverse": "^5.3.0",
         "picomatch": "^4.0.3"
       },
@@ -1869,18 +1897,18 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
       }
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2044,9 +2072,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
-      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2054,9 +2082,9 @@
       }
     },
     "node_modules/@types/pg": {
-      "version": "8.15.6",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
-      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
+      "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -2078,9 +2106,9 @@
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.34",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.34.tgz",
-      "integrity": "sha512-KExbHVa92aJpw9WDQvzBaGVE2/Pz+pLZQloT2hjL8IqsZnV62rlPOYvNnLmf/L2dyllfVUOVBj64M0z/46eR2A==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2095,21 +2123,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.2.tgz",
-      "integrity": "sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.52.0.tgz",
+      "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.46.2",
-        "@typescript-eslint/type-utils": "8.46.2",
-        "@typescript-eslint/utils": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.52.0",
+        "@typescript-eslint/type-utils": "8.52.0",
+        "@typescript-eslint/utils": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2119,7 +2146,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.46.2",
+        "@typescript-eslint/parser": "^8.52.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -2135,18 +2162,18 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
-      "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.52.0.tgz",
+      "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.46.2",
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.52.0",
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2161,15 +2188,15 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.2.tgz",
-      "integrity": "sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.52.0.tgz",
+      "integrity": "sha512-xD0MfdSdEmeFa3OmVqonHi+Cciab96ls1UhIF/qX/O/gPu5KXD0bY9lu33jj04fjzrXHcuvjBcBC+D3SNSadaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.46.2",
-        "@typescript-eslint/types": "^8.46.2",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.52.0",
+        "@typescript-eslint/types": "^8.52.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2183,14 +2210,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.2.tgz",
-      "integrity": "sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.52.0.tgz",
+      "integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2"
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2201,9 +2228,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.2.tgz",
-      "integrity": "sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.52.0.tgz",
+      "integrity": "sha512-jl+8fzr/SdzdxWJznq5nvoI7qn2tNYV/ZBAEcaFMVXf+K6jmXvAFrgo/+5rxgnL152f//pDEAYAhhBAZGrVfwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2218,17 +2245,17 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.2.tgz",
-      "integrity": "sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.52.0.tgz",
+      "integrity": "sha512-JD3wKBRWglYRQkAtsyGz1AewDu3mTc7NtRjR/ceTyGoPqmdS5oCdx/oZMWD5Zuqmo6/MpsYs0wp6axNt88/2EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2",
-        "@typescript-eslint/utils": "8.46.2",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0",
+        "@typescript-eslint/utils": "8.52.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2243,9 +2270,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.2.tgz",
-      "integrity": "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.52.0.tgz",
+      "integrity": "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2257,22 +2284,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.2.tgz",
-      "integrity": "sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.52.0.tgz",
+      "integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.46.2",
-        "@typescript-eslint/tsconfig-utils": "8.46.2",
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.52.0",
+        "@typescript-eslint/tsconfig-utils": "8.52.0",
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2286,16 +2312,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.2.tgz",
-      "integrity": "sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.52.0.tgz",
+      "integrity": "sha512-wYndVMWkweqHpEpwPhwqE2lnD2DxC6WVLupU/DOt/0/v+/+iQbbzO3jOHjmBMnhu0DgLULvOaU4h4pwHYi2oRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.46.2",
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.52.0",
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2310,13 +2336,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.2.tgz",
-      "integrity": "sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.52.0.tgz",
+      "integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.2",
+        "@typescript-eslint/types": "8.52.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -2325,6 +2351,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -2786,6 +2825,15 @@
         "arrow2csv": "bin/arrow2csv.js"
       }
     },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "24.10.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz",
+      "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -2981,6 +3029,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT"
+    },
     "node_modules/babel-jest": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
@@ -3108,9 +3162,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.23",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.23.tgz",
-      "integrity": "sha512-616V5YX4bepJFzNyOfce5Fa8fDJMfoxzOIzDCZwaGL8MKVpFrXqfNUoIpRn9YMI5pXf/VKgzjB4htFMsFKKdiQ==",
+      "version": "2.9.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.13.tgz",
+      "integrity": "sha512-WhtvB2NG2wjr04+h77sg3klAIwrgOqnjS49GGudnUPGFFgg7G17y7Qecqp+2Dr5kUDxNRBca0SK7cG8JwzkWDQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3177,9 +3231,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
-      "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -3198,11 +3252,11 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.19",
-        "caniuse-lite": "^1.0.30001751",
-        "electron-to-chromium": "^1.5.238",
-        "node-releases": "^2.0.26",
-        "update-browserslist-db": "^1.1.4"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3333,9 +3387,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001753",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001753.tgz",
-      "integrity": "sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw==",
+      "version": "1.0.30001763",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001763.tgz",
+      "integrity": "sha512-mh/dGtq56uN98LlNX9qdbKnzINhX0QzhiWBFEkFfsFO4QyCvL8YegrJAazCwXIeqkIob8BlZPGM3xdnY+sgmvQ==",
       "dev": true,
       "funding": [
         {
@@ -3799,9 +3853,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
-      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
+      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -4066,9 +4120,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.244",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.244.tgz",
-      "integrity": "sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw==",
+      "version": "1.5.267",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
+      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
     },
@@ -4102,9 +4156,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
-      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+      "version": "5.18.4",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
+      "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4157,9 +4211,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4324,9 +4378,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.0.tgz",
-      "integrity": "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4337,7 +4391,7 @@
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.0",
+        "@eslint/js": "9.39.2",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -4699,13 +4753,13 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
+      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4722,6 +4776,37 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4736,18 +4821,18 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.0.0.tgz",
+      "integrity": "sha512-+gMeWRrIh/NsG+3NaLeWHuyeyk70p2tbvZIWBYcqQ4/7Xvars6GYTZNhF1sIeLcc6Wb11He5ffz3hsHyXFrw5A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4768,9 +4853,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4904,36 +4989,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4972,16 +5027,6 @@
         "end-of-stream": "^1.4.1"
       }
     },
-    "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -5011,22 +5056,22 @@
       }
     },
     "node_modules/fengari": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.4.tgz",
-      "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.5.tgz",
+      "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "readline-sync": "^1.4.9",
-        "sprintf-js": "^1.1.1",
-        "tmp": "^0.0.33"
+        "readline-sync": "^1.4.10",
+        "sprintf-js": "^1.1.3",
+        "tmp": "^0.2.5"
       }
     },
     "node_modules/fengari-interop": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.3.tgz",
-      "integrity": "sha512-EtZ+oTu3kEwVJnoymFPBVLIbQcCoy9uWCVnMA6h3M/RqHkUBsLYp29+RRHf9rKr6GwjubWREU1O7RretFIXjHw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.4.tgz",
+      "integrity": "sha512-4/CW/3PJUo3ebD4ACgE1g/3NGEYSq7OQAyETyypsAl/WeySDBbxExikkayNkZzbpgyC9GyJp8v1DU2VOXxNq7Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -5355,9 +5400,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5443,13 +5488,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -5756,13 +5794,13 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.2.tgz",
-      "integrity": "sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.1.tgz",
+      "integrity": "sha512-BXNqFQ66oOsR82g9ajFFsR8ZKrjVvYCLyeML9IvSMAsP56XH2VXBdZjmI11p65nXXJxTEt1hie3J2QeFJVgrtQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@ioredis/commands": "1.4.0",
+        "@ioredis/commands": "1.5.0",
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.4",
         "denque": "^2.1.0",
@@ -6808,9 +6846,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/cjs-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6957,9 +6995,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7027,6 +7065,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json11": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/json11/-/json11-2.0.2.tgz",
+      "integrity": "sha512-HIrd50UPYmP6sqLuLbFVm75g16o0oZrVfxrsY0EEys22klz8mRoWlX9KAEDOSOR9Q34rcxsyC8oDveGrCz5uLQ==",
+      "license": "MIT",
+      "bin": {
+        "json11": "dist/cli.mjs"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7082,13 +7129,13 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.6.tgz",
-      "integrity": "sha512-s1gphtDbV4bmW1eylXpVMk2u7is7YsrLl8hzrtvC70h4ByhcMLZFY01Fx05ZUDNuv1H8HO4E+e2zgejV1jVwNw==",
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
+      "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.1",
+        "commander": "^14.0.2",
         "listr2": "^9.0.5",
         "micromatch": "^4.0.8",
         "nano-spawn": "^2.0.0",
@@ -7255,9 +7302,9 @@
       }
     },
     "node_modules/log-update/node_modules/ansi-escapes": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.1.tgz",
-      "integrity": "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
+      "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7424,16 +7471,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -7567,9 +7604,9 @@
       }
     },
     "node_modules/native-copyfiles": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/native-copyfiles/-/native-copyfiles-1.3.6.tgz",
-      "integrity": "sha512-FnfTKOcF9W0LljHUxq+NA/U/s3lxDmdubZSieTmx36K5CFU36WxQqRlhm+D2MClUFDnOLzKgDas/u3zCMIicCQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/native-copyfiles/-/native-copyfiles-1.3.7.tgz",
+      "integrity": "sha512-ZFi2QXlHqCDWcEUQ8DaiyiO8t83VD4PEIZ6nYmW2KwGjVu41jhrm3NgvixvdhV0oauVIscebLGkg4IsUL1H+Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7848,16 +7885,6 @@
       "license": "MIT",
       "dependencies": {
         "forwarded-parse": "^2.1.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/own-keys": {
@@ -8287,9 +8314,9 @@
       }
     },
     "node_modules/postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8327,9 +8354,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8451,27 +8478,6 @@
         {
           "type": "opencollective",
           "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
         }
       ],
       "license": "MIT"
@@ -8712,17 +8718,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -8731,13 +8726,13 @@
       "license": "MIT"
     },
     "node_modules/rimraf": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.0.tgz",
-      "integrity": "sha512-DxdlA1bdNzkZK7JiNWH+BAx1x4tEJWoTofIopFo6qWUU94jYrFZ0ubY05TqH3nWPJ1nKa1JWVFDINZ3fnrle/A==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+      "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^11.0.3",
+        "glob": "^13.0.0",
         "package-json-from-dist": "^1.0.1"
       },
       "bin": {
@@ -8751,37 +8746,15 @@
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
       },
       "engines": {
         "node": "20 || >=22"
@@ -8791,11 +8764,11 @@
       }
     },
     "node_modules/rimraf/node_modules/lru-cache": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
@@ -8817,9 +8790,9 @@
       }
     },
     "node_modules/rimraf/node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -8831,30 +8804,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-array-concat": {
@@ -8928,19 +8877,9 @@
       }
     },
     "node_modules/secure-json-parse": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-3.0.2.tgz",
-      "integrity": "sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
@@ -9722,16 +9661,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {
@@ -9764,9 +9700,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9800,9 +9736,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.5.tgz",
-      "integrity": "sha512-HO3GyiWn2qvTQA4kTgjDcXiMwYQt68a1Y8+JuLRVpdIzm+UOLSHgl/XqR4c6nzJkq5rOkjc02O2I7P7l/Yof0Q==",
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10082,16 +10018,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.2.tgz",
-      "integrity": "sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.52.0.tgz",
+      "integrity": "sha512-atlQQJ2YkO4pfTVQmQ+wvYQwexPDOIgo+RaVcD7gHgzy/IQA+XTyuxNM9M9TVXvttkF7koBHmcwisKdOAf2EcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.46.2",
-        "@typescript-eslint/parser": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2",
-        "@typescript-eslint/utils": "8.46.2"
+        "@typescript-eslint/eslint-plugin": "8.52.0",
+        "@typescript-eslint/parser": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0",
+        "@typescript-eslint/utils": "8.52.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10148,9 +10084,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
-      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -10227,9 +10163,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -10617,9 +10553,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10627,6 +10563,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "7.0.0-rc.0",
+  "version": "7.0.0-rc.1",
   "description": "Tazama package library",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "7.0.0-rc.1",
+  "version": "7.0.0-audit.0",
   "description": "Tazama package library",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@elastic/ecs-pino-format": "^1.5.0",
     "@grpc/grpc-js": "^1.13.4",
     "@grpc/proto-loader": "~0.7.15",
+    "@opensearch-project/opensearch": "^3.5.1",
     "@types/pg": "^8.15.5",
     "@types/uuid": "^10.0.0",
     "dotenv": "^17.2.1",

--- a/src/config/openSearch.config.ts
+++ b/src/config/openSearch.config.ts
@@ -11,9 +11,9 @@ import type { OpenSearchConfig } from '../interfaces/openSearch';
  * const openSearchConfig = openSearchConfig();
  */
 export const openSearchConfig = (): OpenSearchConfig => {
-  const node = validateEnvVar('OPENSEARCH_NODE', 'string').toString();
-  const username = validateEnvVar('OPENSEARCH_USERNAME', 'string').toString();
-  const password = validateEnvVar('OPENSEARCH_PASSWORD', 'string').toString();
+  const node = validateEnvVar('OPENSEARCH_NODE', 'string', true).toString();
+  const username = validateEnvVar('OPENSEARCH_USERNAME', 'string', false)?.toString();
+  const password = validateEnvVar('OPENSEARCH_PASSWORD', 'string', false)?.toString();
   const rejectUnauthorized = validateEnvVar('OPENSEARCH_SSL_REJECT_UNAUTHORIZED', 'boolean', true);
 
   return {

--- a/src/config/openSearch.config.ts
+++ b/src/config/openSearch.config.ts
@@ -1,0 +1,33 @@
+import { validateEnvVar } from '.';
+import type { OpenSearchConfig } from '../interfaces/openSearch';
+
+/**
+ * Validates and retrieves the OpenSearch configuration from environment variables.
+ *
+ * @returns {OpenSearchConfig} - The validated OpenSearch configuration.
+ * @throws {Error} - Throws an error if required environment variables are not defined or invalid.
+ *
+ * @example
+ * const openSearchConfig = openSearchConfig();
+ */
+export const openSearchConfig = (): OpenSearchConfig => {
+  const node = validateEnvVar('OPENSEARCH_NODE', 'string').toString();
+  const username = validateEnvVar('OPENSEARCH_USERNAME', 'string').toString();
+  const password = validateEnvVar('OPENSEARCH_PASSWORD', 'string').toString();
+  const rejectUnauthorized = validateEnvVar('OPENSEARCH_SSL_REJECT_UNAUTHORIZED', 'boolean', true);
+
+  return {
+    node,
+    auth:
+      username && password
+        ? {
+            username,
+            password,
+          }
+        : undefined,
+    ssl: {
+      rejectUnauthorized: Boolean(rejectUnauthorized),
+    },
+    indexPrefix: 'audit-logs',
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import type { RawHistoryDB } from './interfaces/database/RawHistoryDB';
 import { CreateDatabaseManager, type DatabaseManagerInstance, type ManagerConfig } from './services/dbManager';
 import { LoggerService } from './services/logger';
 import { RedisService } from './services/redis';
+import { AuditProvider } from './providers/auditLog.provider';
+import { AuditLogger } from './services/auditLog.service';
 
 export {
   CreateDatabaseManager,
@@ -20,4 +22,6 @@ export {
   type EventHistoryDB,
   type EvaluationDB,
   type RawHistoryDB,
+  AuditProvider,
+  AuditLogger,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import type { RawHistoryDB } from './interfaces/database/RawHistoryDB';
 import { CreateDatabaseManager, type DatabaseManagerInstance, type ManagerConfig } from './services/dbManager';
 import { LoggerService } from './services/logger';
 import { RedisService } from './services/redis';
-import { AuditProvider } from './providers/auditLog.provider';
+import { createAuditProvider } from './providers/auditLog.provider';
 import { AuditLogger } from './services/auditLog.service';
 
 export {
@@ -22,6 +22,6 @@ export {
   type EventHistoryDB,
   type EvaluationDB,
   type RawHistoryDB,
-  AuditProvider,
+  createAuditProvider,
   AuditLogger,
 };

--- a/src/interfaces/openSearch.ts
+++ b/src/interfaces/openSearch.ts
@@ -1,0 +1,26 @@
+export interface OpenSearchConfig {
+  node: string | string[];
+  auth?: {
+    username: string;
+    password: string;
+  };
+  ssl?: {
+    rejectUnauthorized: boolean;
+  };
+  indexPrefix: string;
+}
+
+export interface AuditLogData {
+  serviceName: string;
+  actorId?: string;
+  actorRole?: string;
+  actorName?: string;
+  actorEmail?: string;
+  resourceId?: string;
+  resourceType?: string;
+  sourceIp?: string;
+  description: string;
+  eventType: string;
+  status: 'success' | 'failure' | 'info';
+  metadata?: Record<string, unknown>;
+}

--- a/src/interfaces/openSearch.ts
+++ b/src/interfaces/openSearch.ts
@@ -22,5 +22,7 @@ export interface AuditLogData {
   description: string;
   eventType: string;
   status: 'success' | 'failure' | 'info';
-  metadata?: Record<string, unknown>;
+  tenantId?: string;
+  outcome?: Record<string, unknown>;
+  action_performed?: Record<string, unknown>;
 }

--- a/src/interfaces/openSearch.ts
+++ b/src/interfaces/openSearch.ts
@@ -23,5 +23,5 @@ export interface AuditLogData {
   status: 'success' | 'failure' | 'info';
   tenantId?: string;
   outcome?: Record<string, unknown>;
-  action_performed?: Record<string, unknown>;
+  actionPerformed?: Record<string, unknown>;
 }

--- a/src/interfaces/openSearch.ts
+++ b/src/interfaces/openSearch.ts
@@ -11,7 +11,6 @@ export interface OpenSearchConfig {
 }
 
 export interface AuditLogData {
-  serviceName: string;
   actorId?: string;
   actorRole?: string;
   actorName?: string;

--- a/src/providers/auditLog.provider.ts
+++ b/src/providers/auditLog.provider.ts
@@ -1,10 +1,22 @@
 import { AuditLogger } from '../services/auditLog.service';
 
-export const AuditProvider = {
-  provide: AuditLogger,
-  useFactory: async () => {
+/**
+ * Creates the AuditLogger provider with a specific Service Name.
+ * Use this in your AppModule imports.
+ */
+export const createAuditProvider = (
+  serviceName: string,
+): {
+  provide: string;
+  useFactory: () => Promise<AuditLogger>;
+} => ({
+  provide: 'AUDIT_LOGGER',
+  useFactory: async (): Promise<AuditLogger> => {
     const logger = AuditLogger.getInstance();
-    await logger.init();
+
+    // Initialize it once with the name passed from AppModule
+    await logger.init(serviceName);
+
     return logger;
   },
-};
+});

--- a/src/providers/auditLog.provider.ts
+++ b/src/providers/auditLog.provider.ts
@@ -1,0 +1,10 @@
+import { AuditLogger } from '../services/auditLog.service';
+
+export const AuditProvider = {
+  provide: AuditLogger,
+  useFactory: async () => {
+    const logger = AuditLogger.getInstance();
+    await logger.init();
+    return logger;
+  },
+};

--- a/src/services/auditLog.service.ts
+++ b/src/services/auditLog.service.ts
@@ -7,6 +7,11 @@ export class AuditLogger {
   private readonly client: Client;
   private static instance: AuditLogger;
   private isInitialized = false;
+  private readonly createdIndices = new Set<string>();
+  private readonly creatingIndices = new Map<string, Promise<void>>();
+
+  // 1. Store the service name here
+  private serviceName = 'unknown-service';
 
   private constructor() {
     this.client = new Client({
@@ -43,6 +48,7 @@ export class AuditLogger {
             sourceIp: { type: 'ip' },
             outcome: { type: 'object', enabled: true },
             action_performed: { type: 'object', enabled: true },
+            tenantId: { type: 'keyword' },
           },
         },
         settings: {
@@ -61,24 +67,22 @@ export class AuditLogger {
     }
   }
 
-  /**
-   * Run this once on startup to ensure the Index Template exists.
-   */
-  public async init(): Promise<void> {
-    if (this.isInitialized) return;
+  // 2. Init sets the name once
+  public async init(serviceName: string): Promise<void> {
+    if (this.isInitialized) {
+      return;
+    }
 
     try {
+      this.serviceName = serviceName;
       await this.ensureSchema();
+      // [AuditLogger] Initialized for service
       this.isInitialized = true;
     } catch (error) {
-      // We don't throw here to allow app startup, but logs will fail later if not fixed.
+      // [AuditLogger] Init failed'
     }
   }
 
-  /**
-   * STRICT SYNCHRONOUS LOGGING
-   * Blocks the application until OpenSearch confirms the write.
-   */
   public async log(data: AuditLogData): Promise<void> {
     const date = new Date();
     // Monthly Index: audit-logs-YYYY.MM
@@ -91,7 +95,7 @@ export class AuditLogger {
 
     const doc = {
       timestamp: date.toISOString(),
-      serviceName: data.serviceName,
+      serviceName: this.serviceName,
       actorId: data.actorId,
       actorRole: data.actorRole,
       actorName: data.actorName,
@@ -102,8 +106,8 @@ export class AuditLogger {
       description: data.description,
       eventType: data.eventType,
       status: data.status,
-      action_performed: data.action_performed ?? {},
-      outcome: data.outcome ?? {},
+      action_performed: data.action_performed,
+      outcome: data.outcome,
       tenantId: data.tenantId,
     };
 
@@ -114,7 +118,8 @@ export class AuditLogger {
         refresh: 'wait_for',
       });
     } catch (error) {
-      throw new Error('Audit Log Failed: Transaction Aborted.', error instanceof Error ? error : undefined);
+      const cause = error instanceof Error ? error : new Error(String(error));
+      throw new Error('Audit Log Failed: Transaction Aborted.', { cause });
     }
   }
 }

--- a/src/services/auditLog.service.ts
+++ b/src/services/auditLog.service.ts
@@ -77,6 +77,9 @@ export class AuditLogger {
   }
 
   public async log(data: AuditLogData): Promise<void> {
+    if (!this.isInitialized) {
+      throw new Error('AuditLogService not initialized');
+    }
     const date = new Date();
     // Monthly Index: audit-logs-YYYY.MM
     const MONTH_OFFSET = 1;

--- a/src/services/auditLog.service.ts
+++ b/src/services/auditLog.service.ts
@@ -77,9 +77,6 @@ export class AuditLogger {
   }
 
   public async log(data: AuditLogData): Promise<void> {
-    if (!this.isInitialized) {
-      throw new Error('AuditLogService not initialized');
-    }
     const date = new Date();
     // Monthly Index: audit-logs-YYYY.MM
     const MONTH_OFFSET = 1;

--- a/src/services/auditLog.service.ts
+++ b/src/services/auditLog.service.ts
@@ -38,9 +38,11 @@ export class AuditLogger {
             eventType: { type: 'keyword' },
             description: { type: 'text' },
             status: { type: 'keyword' },
-            resource: { type: 'keyword' },
+            resourceId: { type: 'keyword' },
+            resourceType: { type: 'keyword' },
             sourceIp: { type: 'ip' },
-            metadata: { type: 'object', enabled: true },
+            outcome: { type: 'object', enabled: true },
+            action_performed: { type: 'object', enabled: true },
           },
         },
         settings: {
@@ -100,7 +102,9 @@ export class AuditLogger {
       description: data.description,
       eventType: data.eventType,
       status: data.status,
-      metadata: data.metadata ?? {},
+      action_performed: data.action_performed ?? {},
+      outcome: data.outcome ?? {},
+      tenantId: data.tenantId,
     };
 
     try {

--- a/src/services/auditLog.service.ts
+++ b/src/services/auditLog.service.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Client } from '@opensearch-project/opensearch';
+import { openSearchConfig } from '../config/openSearch.config';
+import type { AuditLogData } from '../interfaces/openSearch';
+
+export class AuditLogger {
+  private readonly client: Client;
+  private static instance: AuditLogger;
+  private isInitialized = false;
+
+  private constructor() {
+    this.client = new Client({
+      node: openSearchConfig().node,
+      auth: openSearchConfig().auth,
+      ssl: openSearchConfig().ssl,
+    });
+  }
+
+  // Singleton Pattern
+  public static getInstance(): AuditLogger {
+    AuditLogger.instance ||= new AuditLogger();
+    return AuditLogger.instance;
+  }
+
+  private async ensureSchema(): Promise<void> {
+    const templateName = 'audit-logs-template';
+    const templateBody = {
+      index_patterns: [`${openSearchConfig().indexPrefix}-*`],
+      template: {
+        mappings: {
+          properties: {
+            timestamp: { type: 'date' },
+            serviceName: { type: 'keyword' },
+            actorId: { type: 'keyword' },
+            actorRole: { type: 'keyword' },
+            actorName: { type: 'text' },
+            actorEmail: { type: 'keyword' },
+            eventType: { type: 'keyword' },
+            description: { type: 'text' },
+            status: { type: 'keyword' },
+            resource: { type: 'keyword' },
+            sourceIp: { type: 'ip' },
+            metadata: { type: 'object', enabled: true },
+          },
+        },
+        settings: {
+          number_of_shards: 1,
+          number_of_replicas: 0,
+        },
+      },
+    };
+
+    const exists = await this.client.indices.existsTemplate({ name: templateName });
+    if (!exists.body) {
+      await this.client.indices.putTemplate({
+        name: templateName,
+        body: templateBody,
+      });
+    }
+  }
+
+  /**
+   * Run this once on startup to ensure the Index Template exists.
+   */
+  public async init(): Promise<void> {
+    if (this.isInitialized) return;
+
+    try {
+      await this.ensureSchema();
+      this.isInitialized = true;
+    } catch (error) {
+      // We don't throw here to allow app startup, but logs will fail later if not fixed.
+    }
+  }
+
+  /**
+   * STRICT SYNCHRONOUS LOGGING
+   * Blocks the application until OpenSearch confirms the write.
+   */
+  public async log(data: AuditLogData): Promise<void> {
+    const date = new Date();
+    // Monthly Index: audit-logs-YYYY.MM
+    const MONTH_OFFSET = 1;
+    const PAD_WIDTH = 2;
+    const PAD_CHAR = '0';
+    const month = date.getMonth() + MONTH_OFFSET;
+    const monthStr = String(month).padStart(PAD_WIDTH, PAD_CHAR);
+    const indexName = `${openSearchConfig().indexPrefix}-${date.getFullYear()}.${monthStr}`;
+
+    const doc = {
+      timestamp: date.toISOString(),
+      serviceName: data.serviceName,
+      actorId: data.actorId,
+      actorRole: data.actorRole,
+      actorName: data.actorName,
+      actorEmail: data.actorEmail,
+      resourceId: data.resourceId,
+      resourceType: data.resourceType,
+      sourceIp: data.sourceIp,
+      description: data.description,
+      eventType: data.eventType,
+      status: data.status,
+      metadata: data.metadata ?? {},
+    };
+
+    try {
+      await this.client.index({
+        index: indexName,
+        body: doc,
+        refresh: 'wait_for',
+      });
+    } catch (error) {
+      throw new Error('Audit Log Failed: Transaction Aborted.', error instanceof Error ? error : undefined);
+    }
+  }
+}

--- a/src/services/auditLog.service.ts
+++ b/src/services/auditLog.service.ts
@@ -7,8 +7,6 @@ export class AuditLogger {
   private readonly client: Client;
   private static instance: AuditLogger;
   private isInitialized = false;
-  private readonly createdIndices = new Set<string>();
-  private readonly creatingIndices = new Map<string, Promise<void>>();
 
   // 1. Store the service name here
   private serviceName = 'unknown-service';
@@ -47,7 +45,7 @@ export class AuditLogger {
             resourceType: { type: 'keyword' },
             sourceIp: { type: 'ip' },
             outcome: { type: 'object', enabled: true },
-            action_performed: { type: 'object', enabled: true },
+            actionPerformed: { type: 'object', enabled: true },
             tenantId: { type: 'keyword' },
           },
         },
@@ -59,7 +57,7 @@ export class AuditLogger {
     };
 
     const exists = await this.client.indices.existsTemplate({ name: templateName });
-    if (!exists.body) {
+    if (exists.statusCode === 404) {
       await this.client.indices.putTemplate({
         name: templateName,
         body: templateBody,
@@ -84,9 +82,9 @@ export class AuditLogger {
     const MONTH_OFFSET = 1;
     const PAD_WIDTH = 2;
     const PAD_CHAR = '0';
-    const month = date.getMonth() + MONTH_OFFSET;
+    const month = date.getUTCMonth() + MONTH_OFFSET;
     const monthStr = String(month).padStart(PAD_WIDTH, PAD_CHAR);
-    const indexName = `${openSearchConfig().indexPrefix}-${date.getFullYear()}.${monthStr}`;
+    const indexName = `${openSearchConfig().indexPrefix}-${date.getUTCFullYear()}.${monthStr}`;
 
     const doc = {
       timestamp: date.toISOString(),
@@ -101,7 +99,7 @@ export class AuditLogger {
       description: data.description,
       eventType: data.eventType,
       status: data.status,
-      action_performed: data.action_performed,
+      actionPerformed: data.actionPerformed,
       outcome: data.outcome,
       tenantId: data.tenantId,
     };

--- a/src/services/auditLog.service.ts
+++ b/src/services/auditLog.service.ts
@@ -73,14 +73,9 @@ export class AuditLogger {
       return;
     }
 
-    try {
-      this.serviceName = serviceName;
-      await this.ensureSchema();
-      // [AuditLogger] Initialized for service
-      this.isInitialized = true;
-    } catch (error) {
-      // [AuditLogger] Init failed'
-    }
+    this.serviceName = serviceName;
+    await this.ensureSchema();
+    this.isInitialized = true;
   }
 
   public async log(data: AuditLogData): Promise<void> {


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenSearch-backed audit logging with injectable provider and new environment variables for OpenSearch connection and SSL handling.

* **Documentation**
  * Added "Audit Logging" guide with setup, usage examples, and environment variable reference.

* **Tests**
  * Added unit tests covering initialization, template management, log delivery, and error handling.

* **Chores**
  * Added local OpenSearch Docker Compose, added OpenSearch client dependency, and bumped package version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->