### PR TITLE
fix: updated the tests for networkMap and getMockNmap

### DIFF
--- a/__tests__/dbManager.test.ts
+++ b/__tests__/dbManager.test.ts
@@ -143,7 +143,7 @@ const getMockRequest = (): Pacs002 => {
 
 const getMockNetworkMap = (): NetworkMap => {
   return JSON.parse(
-    '{"messages":[{"id":"001@1.0.0","host":"http://openfaas:8080","cfg":"1.0.0","txTp":"pain.001.001.11","typologies":[{"id":"028@1.0.0","host":"https://example.com/off-frm-typology-processor","cfg":"1.0.0","rules":[{"id":"003@1.0.0","host":"http://openfaas:8080","cfg":"1.0.0"}]},{"id":"029@1.0.0","host":"https://example.com/function/off-frm-typology-processor","cfg":"1.0.0","rules":[{"id":"003@1.0.0","host":"http://openfaas:8080","cfg":"1.0.0"},{"id":"004@1.0.0","host":"http://openfaas:8080","cfg":"1.0.0"}]}]}]}',
+    '{"active":true,"cfg":"1.0.0","creDtTm":"2024-01-01T00:00:00.000Z","updDtTm":"2024-01-01T00:00:00.000Z","tenantId":"DEFAULT","messages":[{"id":"001@1.0.0","host":"http://openfaas:8080","cfg":"1.0.0","txTp":"pain.001.001.11","typologies":[{"id":"028@1.0.0","host":"https://example.com/off-frm-typology-processor","cfg":"1.0.0","rules":[{"id":"003@1.0.0","host":"http://openfaas:8080","cfg":"1.0.0"}]},{"id":"029@1.0.0","host":"https://example.com/function/off-frm-typology-processor","cfg":"1.0.0","rules":[{"id":"003@1.0.0","host":"http://openfaas:8080","cfg":"1.0.0"},{"id":"004@1.0.0","host":"http://openfaas:8080","cfg":"1.0.0"}]}]}]}',
   );
 };
 

--- a/src/tests/data/networkMap.ts
+++ b/src/tests/data/networkMap.ts
@@ -7,6 +7,8 @@ export const NetworkMapSample: NetworkMap[] = [
     active: true,
     cfg: '',
     tenantId: 'testTenant',
+    creDtTm: '2024-01-01T00:00:00.000Z',
+    updDtTm: '2024-01-01T00:00:00.000Z',
     messages: [
       {
         id: '001@1.0',


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
PR #346 (issue #343) added updDtTm?: string to the NetworkMap, RuleConfig, and TypologyConfig interfaces. While the implementation was correct, the test fixtures and mock factories were never updated to include this new optional field.

## Why are we doing this?
Because updDtTm is optional, this doesn't cause runtime failures today. However, any future snapshot test, round-trip serialisation test, or fixture-driven assertion that expects a fully-populated NetworkMap will silently omit the field and may produce a false-positive pass — tests would appear to succeed while not actually covering the new field. Adding updDtTm to the test data ensures the fixtures accurately represent the full shape of the interfaces going forward.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to include timestamp and metadata fields for improved test coverage of data structure validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->