### PR TITLE
fix: #348 covered - MsgId fallback for e2eid AND both absent case

### DIFF
--- a/__tests__/dbManager.test.ts
+++ b/__tests__/dbManager.test.ts
@@ -716,12 +716,6 @@ describe('CreateDatabaseManager', () => {
 
     expect(dbManager.saveDynamicTransactionHistory).toBeDefined();
 
-    // Test missing EndToEndId
-    const trackedFieldsNoEndToEndId: TrackedFields = {
-      CreDtTm: '2023-01-01T10:00:00Z',
-      TenantId: 'tenant-1',
-    } as TrackedFields;
-
     // Test missing TenantId
     const trackedFieldsNoTenantId: TrackedFields = {
       CreDtTm: '2023-01-01T10:00:00Z',
@@ -742,6 +736,65 @@ describe('CreateDatabaseManager', () => {
       'CreDtTm (creation date/time) is required for transaction history - essential for audit trail',
     );
 
+    dbManager.quit();
+  });
+
+  it('should use MsgId as fallback for endtoendid when EndToEndId is absent', async () => {
+    const transHistoryConfig = {
+      rawHistory: {
+        ...rawHistoryConfig,
+      },
+    };
+    const dbManager = await CreateDatabaseManager(transHistoryConfig);
+
+    const querySpy = jest.spyOn(dbManager._rawHistory, 'query').mockImplementation((): Promise<any> => {
+      return Promise.resolve({ rows: [] });
+    });
+
+    const trackedFieldsNoEndToEndId: TrackedFields = {
+      CreDtTm: '2023-01-01T10:00:00Z',
+      MsgId: 'msg-fallback-123',
+      TenantId: 'tenant-1',
+    } as TrackedFields;
+
+    const mockTransaction: Record<string, unknown> = { id: 'transaction-123' };
+
+    await dbManager.saveDynamicTransactionHistory('test_table', mockTransaction, trackedFieldsNoEndToEndId);
+
+    const calledQuery = querySpy.mock.calls[0][0] as any;
+    // endtoendid is the 4th value ($4) — index 3
+    expect(calledQuery.values[3]).toBe('msg-fallback-123');
+
+    querySpy.mockRestore();
+    dbManager.quit();
+  });
+
+  it('should store undefined in endtoendid when both EndToEndId and MsgId are absent', async () => {
+    const transHistoryConfig = {
+      rawHistory: {
+        ...rawHistoryConfig,
+      },
+    };
+    const dbManager = await CreateDatabaseManager(transHistoryConfig);
+
+    const querySpy = jest.spyOn(dbManager._rawHistory, 'query').mockImplementation((): Promise<any> => {
+      return Promise.resolve({ rows: [] });
+    });
+
+    const trackedFieldsNeitherEndToEndIdNorMsgId: TrackedFields = {
+      CreDtTm: '2023-01-01T10:00:00Z',
+      TenantId: 'tenant-1',
+    } as TrackedFields;
+
+    const mockTransaction: Record<string, unknown> = { id: 'transaction-123' };
+
+    await dbManager.saveDynamicTransactionHistory('test_table', mockTransaction, trackedFieldsNeitherEndToEndIdNorMsgId);
+
+    const calledQuery = querySpy.mock.calls[0][0] as any;
+    // When both are absent, endtoendid ($4) is undefined — acceptable for Connection Studio messages
+    expect(calledQuery.values[3]).toBeUndefined();
+
+    querySpy.mockRestore();
     dbManager.quit();
   });
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

We added two new test cases to __tests__/dbManager.test.ts and cleaned up dead code:

New test: MsgId fallback — A test that calls [saveDynamicTransactionHistory] with a [TrackedFields] object containing [MsgId] but no [EndToEndId] and asserts that [MsgId]( is stored in the endtoendid column ([values[3]].

New test: both-absent case — A test that calls [saveDynamicTransactionHistory] with neither [EndToEndId] nor [MsgId], and asserts that undefined is stored in endtoendid, documenting this as acceptable behaviour for Connection Studio messages.

Removed dead variable — The unused [trackedFieldsNoEndToEndId] declaration in the existing "missing required tracked fields" test was removed (it was declared but never used in any assertion).

## Why are we doing this?

The SaveDynamicTransactionHistory function in src/builders/rawHistoryBuilder.ts was updated (merged in feat-paysys-DME) to make EndToEndId optional, with a fallback to [trackedFields.MsgId] for the endtoendid column:
trackedFields.EndToEndId?.trim() ?? trackedFields.MsgId?.trim(),


## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation tests for transaction identifier handling
  * Improved test coverage for scenarios where optional transaction identifiers are absent
  * Strengthened reliability verification for transaction history management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->