### PR TITLE
feat: add onConfigLoaded callback to configurationBuilder for config pre-validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,23 @@ The ManagerConfig interface allows you to define which databases and services yo
 - **Configuration Database**: Store and retrieve application configurations. `Optional`
 - **Redis Cache**: Use Redis for caching to improve performance. `Optional`
 - **Local Cache**: Option for using local cache (Node cache) to improve performance. `Optional` Note: This object is heavily used by configuration builder
+- **Hooks**: Optional lifecycle callbacks for the configuration database. Currently supports `onConfigLoaded`, which fires once per unique rule config key after a successful DB fetch and before the result is stored in local cache. Use this to validate or reject a config at load time rather than on every transaction. If the callback throws, the config is not cached and the error propagates to the caller.
+
+**Hooks usage example:**
+
+```typescript
+import { CreateStorageManager, type DatabaseManagerHooks } from '@tazama-lf/frms-coe-lib';
+
+const hooks: DatabaseManagerHooks = {
+  onConfigLoaded: (config) => {
+    if (!config.config?.bands?.length) {
+      throw new Error('Invalid config - bands not provided');
+    }
+  },
+};
+
+const { db } = await CreateStorageManager([Database.CONFIGURATION], false, hooks);
+```
 
 ### Usage Example
 The JSON object example for dbManage configuration

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ The ManagerConfig interface allows you to define which databases and services yo
 
 ```typescript
 import { CreateStorageManager, type DatabaseManagerHooks } from '@tazama-lf/frms-coe-lib';
+import { Database } from '@tazama-lf/frms-coe-lib/lib/config/database.config';
 
 const hooks: DatabaseManagerHooks = {
   onConfigLoaded: (config) => {

--- a/__tests__/configurationBuilder.test.ts
+++ b/__tests__/configurationBuilder.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { configurationBuilder } from '../src/builders/configurationBuilder';
+import type { RuleConfig } from '../src/interfaces';
 import type { ConfigurationDB, DBConfig } from '../src/services/dbManager';
 
 // redis and postgres are mocked in setup.jest.js
@@ -164,6 +165,75 @@ describe('ConfigurationBuilder', () => {
       jest.spyOn(manager._configuration, 'query').mockRejectedValue(mockError as never);
 
       await expect(manager.insertJobHistory('tenant1', 'job1', 10, 5, null, 'push')).rejects.toThrow('Query execution failed');
+    });
+  });
+
+  describe('getRuleConfig - onConfigLoaded callback', () => {
+    const mockRuleConfig: RuleConfig = {
+      id: '001@1.0.0',
+      cfg: '1.0.0',
+      tenantId: 'DEFAULT',
+      desc: 'Test rule config',
+      config: {
+        parameters: {},
+        exitConditions: [],
+        bands: [],
+      },
+    };
+
+    it('should invoke onConfigLoaded with the fetched config on a cache miss', async () => {
+      const onConfigLoaded = jest.fn();
+      await configurationBuilder(manager, configurationConfig, { localCacheEnabled: true }, onConfigLoaded);
+      jest.spyOn(manager._configuration, 'query').mockResolvedValue({ rows: [{ configuration: mockRuleConfig }] } as never);
+
+      const result = await manager.getRuleConfig('001', '1.0.0', 'DEFAULT');
+
+      expect(onConfigLoaded).toHaveBeenCalledTimes(1);
+      expect(onConfigLoaded).toHaveBeenCalledWith(mockRuleConfig);
+      expect(result).toEqual(mockRuleConfig);
+    });
+
+    it('should not invoke onConfigLoaded on a cache hit', async () => {
+      const onConfigLoaded = jest.fn();
+      await configurationBuilder(manager, configurationConfig, { localCacheEnabled: true }, onConfigLoaded);
+      jest.spyOn(manager._configuration, 'query').mockResolvedValue({ rows: [{ configuration: mockRuleConfig }] } as never);
+
+      // First call - cache miss, populates cache
+      await manager.getRuleConfig('001', '1.0.0', 'DEFAULT');
+      onConfigLoaded.mockClear();
+
+      // Second call - cache hit
+      const result = await manager.getRuleConfig('001', '1.0.0', 'DEFAULT');
+
+      expect(onConfigLoaded).not.toHaveBeenCalled();
+      expect(result).toEqual(mockRuleConfig);
+    });
+
+    it('should not cache the config and should propagate the error when onConfigLoaded throws', async () => {
+      const validationError = new Error('Invalid config - bands not provided');
+      const onConfigLoaded = jest.fn().mockImplementation(() => {
+        throw validationError;
+      });
+      await configurationBuilder(manager, configurationConfig, { localCacheEnabled: true }, onConfigLoaded);
+      jest.spyOn(manager._configuration, 'query').mockResolvedValue({ rows: [{ configuration: mockRuleConfig }] } as never);
+
+      // First call - throws from onConfigLoaded
+      await expect(manager.getRuleConfig('001', '1.0.0', 'DEFAULT')).rejects.toThrow('Invalid config - bands not provided');
+
+      // Second call - cache miss again (bad config was never stored)
+      onConfigLoaded.mockReset();
+      jest.spyOn(manager._configuration, 'query').mockResolvedValue({ rows: [{ configuration: mockRuleConfig }] } as never);
+      await manager.getRuleConfig('001', '1.0.0', 'DEFAULT');
+      expect(onConfigLoaded).toHaveBeenCalledTimes(1);
+    });
+
+    it('should work as before when no onConfigLoaded callback is provided', async () => {
+      await configurationBuilder(manager, configurationConfig, { localCacheEnabled: true });
+      jest.spyOn(manager._configuration, 'query').mockResolvedValue({ rows: [{ configuration: mockRuleConfig }] } as never);
+
+      const result = await manager.getRuleConfig('001', '1.0.0', 'DEFAULT');
+
+      expect(result).toEqual(mockRuleConfig);
     });
   });
 });

--- a/__tests__/ruleConfigSchema.test.ts
+++ b/__tests__/ruleConfigSchema.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+import {
+  baseRuleConfigSchema,
+  BandSchema,
+  OutcomeResultSchema,
+  ExpressionSchema,
+  CaseSchema,
+  TimeframeSchema,
+  baseConfigSchema,
+} from '../src/schemas/ruleConfig';
+
+const validConfig = {
+  id: '901@1.0.0',
+  cfg: '1.0.0',
+  tenantId: 'DEFAULT',
+  config: {},
+};
+
+describe('baseRuleConfigSchema', () => {
+  it('should accept a minimal valid RuleConfig', () => {
+    expect(() => baseRuleConfigSchema.parse(validConfig)).not.toThrow();
+  });
+
+  it('should accept a fully populated RuleConfig', () => {
+    const full = {
+      ...validConfig,
+      desc: 'Test rule',
+      creDtTm: '2024-01-01T00:00:00.000Z',
+      updDtTm: '2024-01-02T00:00:00.000Z',
+      config: {
+        parameters: { maxQueryRange: 86400000 },
+        exitConditions: [{ subRuleRef: '.x00', reason: 'Unsuccessful transaction' }],
+        bands: [
+          { subRuleRef: '.01', reason: 'Low', upperLimit: 10 },
+          { subRuleRef: '.02', reason: 'High', lowerLimit: 10 },
+        ],
+        timeframes: [{ threshold: 3600 }],
+      },
+    };
+    expect(() => baseRuleConfigSchema.parse(full)).not.toThrow();
+  });
+
+  it('should reject when id is missing', () => {
+    const { id: _id, ...noId } = validConfig;
+    expect(() => baseRuleConfigSchema.parse(noId)).toThrow();
+  });
+
+  it('should reject when cfg is missing', () => {
+    const { cfg: _cfg, ...noCfg } = validConfig;
+    expect(() => baseRuleConfigSchema.parse(noCfg)).toThrow();
+  });
+
+  it('should reject when tenantId is missing', () => {
+    const { tenantId: _t, ...noTenant } = validConfig;
+    expect(() => baseRuleConfigSchema.parse(noTenant)).toThrow();
+  });
+
+  it('should reject when config is missing', () => {
+    const { config: _c, ...noConfig } = validConfig;
+    expect(() => baseRuleConfigSchema.parse(noConfig)).toThrow();
+  });
+
+  it('should accept config with all optional fields absent', () => {
+    const result = baseRuleConfigSchema.parse({ ...validConfig, config: {} });
+    expect(result.config).toEqual({});
+  });
+});
+
+describe('OutcomeResultSchema', () => {
+  it('should accept valid outcome result', () => {
+    expect(() => OutcomeResultSchema.parse({ subRuleRef: '.x00', reason: 'Exit' })).not.toThrow();
+  });
+
+  it('should reject when subRuleRef is missing', () => {
+    expect(() => OutcomeResultSchema.parse({ reason: 'Exit' })).toThrow();
+  });
+
+  it('should reject when reason is missing', () => {
+    expect(() => OutcomeResultSchema.parse({ subRuleRef: '.x00' })).toThrow();
+  });
+});
+
+describe('BandSchema', () => {
+  it('should accept a band with only required fields', () => {
+    expect(() => BandSchema.parse({ subRuleRef: '.01', reason: 'Low' })).not.toThrow();
+  });
+
+  it('should accept a band with limits', () => {
+    expect(() => BandSchema.parse({ subRuleRef: '.01', reason: 'Low', lowerLimit: 0, upperLimit: 100 })).not.toThrow();
+  });
+
+  it('should reject non-numeric limits', () => {
+    expect(() => BandSchema.parse({ subRuleRef: '.01', reason: 'Low', lowerLimit: 'ten' })).toThrow();
+  });
+});
+
+describe('ExpressionSchema', () => {
+  it('should accept valid expression', () => {
+    expect(() => ExpressionSchema.parse({ subRuleRef: '.01', reason: 'Match', value: 'ACCC' })).not.toThrow();
+  });
+
+  it('should reject when value is missing', () => {
+    expect(() => ExpressionSchema.parse({ subRuleRef: '.01', reason: 'Match' })).toThrow();
+  });
+});
+
+describe('CaseSchema', () => {
+  it('should accept valid case', () => {
+    expect(() =>
+      CaseSchema.parse({
+        expressions: [{ subRuleRef: '.01', reason: 'Match', value: 'ACCC' }],
+        alternative: { subRuleRef: '.00', reason: 'No match' },
+      }),
+    ).not.toThrow();
+  });
+
+  it('should accept case with empty expressions array', () => {
+    expect(() => CaseSchema.parse({ expressions: [], alternative: { subRuleRef: '.00', reason: 'No match' } })).not.toThrow();
+  });
+
+  it('should reject when alternative is missing', () => {
+    expect(() => CaseSchema.parse({ expressions: [] })).toThrow();
+  });
+});
+
+describe('TimeframeSchema', () => {
+  it('should accept valid timeframe', () => {
+    expect(() => TimeframeSchema.parse({ threshold: 3600 })).not.toThrow();
+  });
+
+  it('should reject non-numeric threshold', () => {
+    expect(() => TimeframeSchema.parse({ threshold: 'one hour' })).toThrow();
+  });
+
+  it('should reject missing threshold', () => {
+    expect(() => TimeframeSchema.parse({})).toThrow();
+  });
+});
+
+describe('baseConfigSchema', () => {
+  it('should accept empty config', () => {
+    expect(() => baseConfigSchema.parse({})).not.toThrow();
+  });
+
+  it('should accept all optional fields populated', () => {
+    expect(() =>
+      baseConfigSchema.parse({
+        parameters: { maxQueryRange: 86400000 },
+        exitConditions: [{ subRuleRef: '.x00', reason: 'Exit' }],
+        bands: [{ subRuleRef: '.01', reason: 'Low', upperLimit: 10 }],
+        cases: { expressions: [], alternative: { subRuleRef: '.00', reason: 'Default' } },
+        timeframes: [{ threshold: 3600 }],
+      }),
+    ).not.toThrow();
+  });
+
+  it('should reject malformed bands entry', () => {
+    expect(() => baseConfigSchema.parse({ bands: [{ notAField: true }] })).toThrow();
+  });
+});

--- a/__tests__/ruleConfigSchema.test.ts
+++ b/__tests__/ruleConfigSchema.test.ts
@@ -5,7 +5,6 @@ import {
   OutcomeResultSchema,
   ExpressionSchema,
   CaseSchema,
-  TimeframeSchema,
   baseConfigSchema,
 } from '../src/schemas/ruleConfig';
 
@@ -34,7 +33,6 @@ describe('baseRuleConfigSchema', () => {
           { subRuleRef: '.01', reason: 'Low', upperLimit: 10 },
           { subRuleRef: '.02', reason: 'High', lowerLimit: 10 },
         ],
-        timeframes: [{ threshold: 3600 }],
       },
     };
     expect(() => baseRuleConfigSchema.parse(full)).not.toThrow();
@@ -123,20 +121,6 @@ describe('CaseSchema', () => {
   });
 });
 
-describe('TimeframeSchema', () => {
-  it('should accept valid timeframe', () => {
-    expect(() => TimeframeSchema.parse({ threshold: 3600 })).not.toThrow();
-  });
-
-  it('should reject non-numeric threshold', () => {
-    expect(() => TimeframeSchema.parse({ threshold: 'one hour' })).toThrow();
-  });
-
-  it('should reject missing threshold', () => {
-    expect(() => TimeframeSchema.parse({})).toThrow();
-  });
-});
-
 describe('baseConfigSchema', () => {
   it('should accept empty config', () => {
     expect(() => baseConfigSchema.parse({})).not.toThrow();
@@ -149,7 +133,6 @@ describe('baseConfigSchema', () => {
         exitConditions: [{ subRuleRef: '.x00', reason: 'Exit' }],
         bands: [{ subRuleRef: '.01', reason: 'Low', upperLimit: 10 }],
         cases: { expressions: [], alternative: { subRuleRef: '.00', reason: 'Default' } },
-        timeframes: [{ threshold: 3600 }],
       }),
     ).not.toThrow();
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.0.0-rc.4",
+  "version": "8.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "8.0.0-rc.4",
+      "version": "8.0.0-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "pino": "^9.9.0",
         "pino-elasticsearch": "^8.1.0",
         "protobufjs": "^7.5.5",
-        "uuid": "^11.1.1"
+        "uuid": "^11.1.1",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
@@ -10623,6 +10624,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.0.0-rc.3",
+  "version": "8.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "8.0.0-rc.3",
+      "version": "8.0.0-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.0.0-rc.3",
+  "version": "8.0.0-rc.4",
   "description": "Tazama package library",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.0.0-rc.4",
+  "version": "8.0.0-rc.5",
   "description": "Tazama package library",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "pino": "^9.9.0",
     "pino-elasticsearch": "^8.1.0",
     "protobufjs": "^7.5.5",
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "zod": "^4.4.3"
   },
   "keywords": [],
   "author": "Tazama.org",

--- a/src/builders/configurationBuilder.ts
+++ b/src/builders/configurationBuilder.ts
@@ -15,6 +15,7 @@ export async function configurationBuilder(
   manager: ConfigurationDB,
   configurationConfig: DBConfig,
   cacheConfig?: LocalCacheConfig,
+  onConfigLoaded?: (config: RuleConfig) => void,
 ): Promise<void> {
   const conf: PoolConfig = {
     host: configurationConfig.host,
@@ -63,8 +64,11 @@ export async function configurationBuilder(
     const queryRes = await manager._configuration.query<{ configuration: RuleConfig }>(query);
 
     const toReturn = queryRes.rows.length > 0 ? queryRes.rows[0].configuration : undefined;
-    if (toReturn && manager.nodeCache) {
-      manager.nodeCache.set(cacheKey, toReturn, cacheConfig?.localCacheTTL ?? 3000);
+    if (toReturn) {
+      onConfigLoaded?.(toReturn);
+      if (manager.nodeCache) {
+        manager.nodeCache.set(cacheKey, toReturn, cacheConfig?.localCacheTTL ?? 3000);
+      }
     }
     return toReturn;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,6 @@ export {
   BandSchema,
   ExpressionSchema,
   CaseSchema,
-  TimeframeSchema,
   baseConfigSchema,
   baseRuleConfigSchema,
 } from './schemas/ruleConfig';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,13 @@ import type { PgQueryConfig } from './builders/utils';
 import { validateTableName } from './builders/utils';
 import type { EvaluationDB } from './interfaces/database/EvaluationDB';
 import type { RawHistoryDB } from './interfaces/database/RawHistoryDB';
-import { CreateDatabaseManager, type DatabaseManagerInstance, type ManagerConfig } from './services/dbManager';
+import {
+  CreateDatabaseManager,
+  CreateStorageManager,
+  type DatabaseManagerHooks,
+  type DatabaseManagerInstance,
+  type ManagerConfig,
+} from './services/dbManager';
 import { LoggerService } from './services/logger';
 import { RedisService } from './services/redis';
 import type { EnrichmentDB } from './interfaces/database/EnrichmentDB';
@@ -22,6 +28,7 @@ import {
 
 export {
   CreateDatabaseManager,
+  CreateStorageManager,
   LoggerService,
   RedisService,
   createSafeObjectFromEndpoint,
@@ -33,6 +40,7 @@ export {
   isPain013Transaction,
   validateTableName,
   type ConfigurationDB,
+  type DatabaseManagerHooks,
   type DatabaseManagerInstance,
   type ManagerConfig,
   type PgQueryConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,3 +51,12 @@ export {
 };
 
 export type * from './interfaces';
+export {
+  OutcomeResultSchema,
+  BandSchema,
+  ExpressionSchema,
+  CaseSchema,
+  TimeframeSchema,
+  baseConfigSchema,
+  baseRuleConfigSchema,
+} from './schemas/ruleConfig';

--- a/src/schemas/ruleConfig.ts
+++ b/src/schemas/ruleConfig.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { z } from 'zod';
+
+export const OutcomeResultSchema = z.object({
+  subRuleRef: z.string(),
+  reason: z.string(),
+});
+
+export const BandSchema = OutcomeResultSchema.extend({
+  lowerLimit: z.number().optional(),
+  upperLimit: z.number().optional(),
+});
+
+export const ExpressionSchema = OutcomeResultSchema.extend({
+  value: z.string(),
+});
+
+export const CaseSchema = z.object({
+  expressions: z.array(ExpressionSchema),
+  alternative: OutcomeResultSchema,
+});
+
+export const TimeframeSchema = z.object({
+  threshold: z.number(),
+});
+
+export const baseConfigSchema = z.object({
+  parameters: z.record(z.union([z.string(), z.number()]), z.unknown()).optional(),
+  exitConditions: z.array(OutcomeResultSchema).optional(),
+  bands: z.array(BandSchema).optional(),
+  cases: CaseSchema.optional(),
+  timeframes: z.array(TimeframeSchema).optional(),
+});
+
+export const baseRuleConfigSchema = z.object({
+  id: z.string(),
+  cfg: z.string(),
+  tenantId: z.string(),
+  desc: z.string().optional(),
+  creDtTm: z.string().optional(),
+  updDtTm: z.string().optional(),
+  config: baseConfigSchema,
+});

--- a/src/schemas/ruleConfig.ts
+++ b/src/schemas/ruleConfig.ts
@@ -21,16 +21,11 @@ export const CaseSchema = z.object({
   alternative: OutcomeResultSchema,
 });
 
-export const TimeframeSchema = z.object({
-  threshold: z.number(),
-});
-
 export const baseConfigSchema = z.object({
   parameters: z.record(z.union([z.string(), z.number()]), z.unknown()).optional(),
   exitConditions: z.array(OutcomeResultSchema).optional(),
   bands: z.array(BandSchema).optional(),
   cases: CaseSchema.optional(),
-  timeframes: z.array(TimeframeSchema).optional(),
 });
 
 export const baseRuleConfigSchema = z.object({

--- a/src/services/dbManager.ts
+++ b/src/services/dbManager.ts
@@ -10,13 +10,18 @@ import { redisBuilder } from '../builders/redisBuilder';
 import { type Database, validateDatabaseConfig } from '../config/database.config';
 import { validateLocalCacheConfig } from '../config/index';
 import { Cache, validateRedisConfig } from '../config/redis.config';
-import type { RedisConfig } from '../interfaces';
+import type { RedisConfig, RuleConfig } from '../interfaces';
+
 import type { ConfigurationDB } from '../interfaces/database/ConfigurationDB';
 import type { EvaluationDB } from '../interfaces/database/EvaluationDB';
 import type { EventHistoryDB } from '../interfaces/database/EventHistoryDB';
 import type { RawHistoryDB } from '../interfaces/database/RawHistoryDB';
 import { enrichmentBuilder } from '../builders/enrichmentBuilder';
 import type { EnrichmentDB } from '../interfaces/database/EnrichmentDB';
+
+export interface DatabaseManagerHooks {
+  onConfigLoaded?: (config: RuleConfig) => void;
+}
 
 export let readyChecks: Record<string, unknown> = {};
 
@@ -74,7 +79,10 @@ type DatabaseManagerInstance<T extends ManagerConfig> = ManagerStatus &
  * @param {T} config ManagerStatus | RedisService | EventHistoryDB | RawHistoryDB | ConfigurationDB
  * @return {*}  {Promise<DatabaseManagerInstance<T>>}
  */
-export async function CreateDatabaseManager<T extends ManagerConfig>(config: T): Promise<DatabaseManagerInstance<T>> {
+export async function CreateDatabaseManager<T extends ManagerConfig>(
+  config: T,
+  hooks?: DatabaseManagerHooks,
+): Promise<DatabaseManagerInstance<T>> {
   const manager: DatabaseManagerType = {};
   readyChecks = {};
   const redis = config.redisConfig ? await redisBuilder(manager, config.redisConfig) : null;
@@ -92,7 +100,7 @@ export async function CreateDatabaseManager<T extends ManagerConfig>(config: T):
   }
 
   if (config.configuration) {
-    await configurationBuilder(manager as ConfigurationDB, config.configuration, config.localCacheConfig);
+    await configurationBuilder(manager as ConfigurationDB, config.configuration, config.localCacheConfig, hooks?.onConfigLoaded);
   }
 
   if (config.enrichment) {
@@ -121,6 +129,7 @@ export async function CreateDatabaseManager<T extends ManagerConfig>(config: T):
 export async function CreateStorageManager<T extends ManagerConfig>(
   requiredStorages: Array<Database | Cache>,
   requireAuth = false,
+  hooks?: DatabaseManagerHooks,
 ): Promise<{ db: DatabaseManagerInstance<T>; config: ManagerConfig }> {
   let config: ManagerConfig = {};
 
@@ -138,7 +147,7 @@ export async function CreateStorageManager<T extends ManagerConfig>(
   }
 
   if (!Object.values(config).every((value) => value === undefined)) {
-    return { db: (await CreateDatabaseManager(config)) as DatabaseManagerInstance<T>, config };
+    return { db: (await CreateDatabaseManager(config, hooks)) as DatabaseManagerInstance<T>, config };
   } else {
     throw Error('Configuration supplied to Database manager was not valid.');
   }


### PR DESCRIPTION
## Summary

Adds an optional `onConfigLoaded` callback hook to `configurationBuilder`, threaded through `CreateDatabaseManager` and `CreateStorageManager`. The callback fires once per unique rule config key after a successful DB fetch and before the result is stored in Node Cache.

**Behaviour:**
- If the callback throws, the config is not cached and the error propagates to the caller
- If the callback is not provided, the code path is entirely unchanged (backwards compatible)
- On a cache hit the callback is not invoked (it already ran when the config was first loaded)

**API changes:**

```typescript
// configurationBuilder - new optional 4th parameter
async function configurationBuilder(
  manager, configurationConfig, cacheConfig?,
  onConfigLoaded?: (config: RuleConfig) => void,
)

// CreateDatabaseManager - new optional 2nd parameter
async function CreateDatabaseManager<T extends ManagerConfig>(
  config: T,
  hooks?: DatabaseManagerHooks,
)

// CreateStorageManager - new optional 3rd parameter
async function CreateStorageManager<T extends ManagerConfig>(
  requiredStorages: Array<Database | Cache>,
  requireAuth?: boolean,
  hooks?: DatabaseManagerHooks,
)

// New exported type
export interface DatabaseManagerHooks {
  onConfigLoaded?: (config: RuleConfig) => void;
}
```

**Unit tests added** (4 new tests in `__tests__/configurationBuilder.test.ts`):
- Callback is invoked with the fetched config on a cache miss
- Callback is not invoked on a cache hit
- If the callback throws, the config is not cached and the error propagates
- No callback provided - works exactly as before (backwards compat)

**Documentation:** README updated with `hooks` usage example.

Closes #382

## Related

- Follow-up: tazama-lf/rule-executer#406 - wire `validateConfig` from rule module into `configurationBuilder` via this hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional lifecycle callback that notifies consumers when a rule configuration is loaded and affects caching behavior.
  * Added and re-exported validation schemas for rule configuration structures.

* **Documentation**
  * README updated with a "Hooks" section and usage examples for the new callback.

* **Tests**
  * Expanded tests covering callback invocation, cache interactions, and error propagation.

* **Chores**
  * Version bumped to 8.0.0-rc.4.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/frms-coe-lib/pull/383)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->