### PR TITLE
feat: add event-adjudicator as recognised processor name in networkMapIdentifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.0.0-rc.5",
+  "version": "8.1.0-rc.0",
   "description": "Tazama package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/helpers/networkMapIdentifiers.ts
+++ b/src/helpers/networkMapIdentifiers.ts
@@ -50,6 +50,7 @@ export const getRoutesFromNetworkMap = async (
         consumers: rulesIds.map((eachRuleId) => 'pub-rule-' + eachRuleId),
       };
     case 'transaction-aggregation-decisioning-processor':
+    case 'event-adjudicator':
       return {
         consumers: typologyCfg.map((eachTypologyCfg) => 'typology-' + eachTypologyCfg),
       };


### PR DESCRIPTION
## Summary

Adds `case 'event-adjudicator':` as a fall-through to the existing `case 'transaction-aggregation-decisioning-processor':` block in `networkMapIdentifiers.ts`, so that TADProc's renamed `FUNCTION_NAME` is recognised and subscribes to the correct typology consumers.

The old case is kept for backward compatibility until the rename is confirmed stable in production.

Bumps version to `8.1.0-rc.0` (minor bump, new feature). Published to npm with tag `rc`.

## Changes

- `src/helpers/networkMapIdentifiers.ts` - added `case 'event-adjudicator':` fall-through
- `package.json` - version bumped from `8.0.0-rc.5` to `8.1.0-rc.0`

## Related

Closes #411
Part of tazama-lf/transaction-aggregation-decisioning-processor#416
