### PR TITLE
feat: add simulation builder and make SIMULATION_DATABASE optional

### DIFF
--- a/__tests__/simulationBuilder.test.ts
+++ b/__tests__/simulationBuilder.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { simulationBuilder } from '../src/builders/simulationBuilder';
+import type { SimulationDB } from '../src/interfaces/database/SimulationDB';
+import type { DBConfig } from '../src/services/dbManager';
+import { readyChecks } from '../src/services/dbManager';
+
+// redis and postgres are mocked in setup.jest.js
+
+const simulationConfig: DBConfig = {
+  certPath: 'TestSimulation',
+  databaseName: 'TestSimulation',
+  user: 'TestSimulation',
+  password: 'TestSimulation',
+  host: 'TestSimulation',
+  port: 5432,
+};
+
+describe('SimulationBuilder', () => {
+  let manager: SimulationDB;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    manager = {} as SimulationDB;
+  });
+
+  afterEach(() => {
+    if (manager._simulation) {
+      manager._simulation.end();
+    }
+  });
+
+  describe('getSimulationMessages', () => {
+    beforeEach(async () => {
+      await simulationBuilder(manager, simulationConfig);
+    });
+
+    it('should set SimulationDB ready check to Ok on successful init', () => {
+      expect(readyChecks.SimulationDB).toBe('Ok');
+    });
+
+    it('should query simulation messages for a tenant with default limit and offset', async () => {
+      const tenantId = 'test-tenant';
+      const mockRows = [{ messageId: 'msg-1', timestamp: '2024-01-01T00:00:00Z', endpoint: '/api/test', data: { key: 'value' } }];
+      jest.spyOn(manager._simulation, 'query').mockResolvedValue({ rows: mockRows } as never);
+
+      const result = await manager.getSimulationMessages(tenantId);
+
+      expect(manager._simulation.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('SELECT'),
+          values: [tenantId, 1000, 0],
+        }),
+      );
+      expect(result).toEqual(mockRows);
+    });
+
+    it('should respect custom limit and offset', async () => {
+      jest.spyOn(manager._simulation, 'query').mockResolvedValue({ rows: [] } as never);
+
+      await manager.getSimulationMessages('tenant-id', 50, 100);
+
+      expect(manager._simulation.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          values: ['tenant-id', 50, 100],
+        }),
+      );
+    });
+
+    it('should return an empty array when no messages exist', async () => {
+      jest.spyOn(manager._simulation, 'query').mockResolvedValue({ rows: [] } as never);
+
+      const result = await manager.getSimulationMessages('empty-tenant');
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.0.0-rc.5",
+  "version": "8.1.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "8.0.0-rc.5",
+      "version": "8.1.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -80,6 +80,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1636,6 +1637,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2025,6 +2027,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
       "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2112,6 +2115,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -2603,6 +2607,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3189,6 +3194,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4321,6 +4327,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5011,6 +5018,7 @@
       "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.10",
         "sprintf-js": "^1.1.3",
@@ -5768,6 +5776,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -6364,6 +6373,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -7999,6 +8009,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9767,6 +9778,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9967,6 +9979,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.1.0-rc.0",
+  "version": "8.1.0-rc.1",
   "description": "Tazama package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/builders/eventHistoryBuilder.ts
+++ b/src/builders/eventHistoryBuilder.ts
@@ -2,6 +2,7 @@
 
 import * as util from 'node:util';
 import { Pool, type PoolConfig } from 'pg';
+import pgFormat from 'pg-format';
 import { isDatabaseReady } from '../builders/utils';
 import type { AccountCondition, ConditionEdge, EntityCondition, TransactionDetails } from '../interfaces';
 import type { PgQueryConfig } from '../interfaces/database';
@@ -39,8 +40,6 @@ export async function eventHistoryBuilder(manager: EventHistoryDB, eventHistoryC
     await manager._eventHistory.query(query);
   };
 
-  // -----
-  // table name is already safe - validated at DEMS level - and this function is only used internally with fixed table names, so no risk of SQL injection
   manager.saveInDataModelTable = async (
     tableName: string,
     key: string,
@@ -48,8 +47,13 @@ export async function eventHistoryBuilder(manager: EventHistoryDB, eventHistoryC
     tenantId: string,
     creDtTm: string,
   ): Promise<void> => {
+    if (!/^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/.test(tableName)) {
+      throw new Error(
+        `Invalid table name format: ${tableName}. Table names must start with a letter or underscore and contain only letters, digits, and underscores (max 63 characters).`,
+      );
+    }
     const query: PgQueryConfig = {
-      text: `INSERT INTO ${tableName} (_key, data, tenantId, creDtTm) VALUES ($1, $2, $3, $4) ON CONFLICT (_key) DO NOTHING`,
+      text: pgFormat('INSERT INTO %I (_key, data, tenantId, creDtTm) VALUES ($1, $2, $3, $4) ON CONFLICT (_key) DO NOTHING', tableName),
       values: [key, data, tenantId, creDtTm],
     };
 

--- a/src/builders/simulationBuilder.ts
+++ b/src/builders/simulationBuilder.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import * as util from 'node:util';
+import { Pool, type PoolConfig } from 'pg';
+import { isDatabaseReady } from '../builders/utils';
+import type { PgQueryConfig } from '../interfaces/database';
+import type { SimulationDB, SimulationMessage } from '../interfaces/database/SimulationDB';
+import { type DBConfig, readyChecks } from '../services/dbManager';
+import { getSSLConfig } from './utils';
+
+export async function simulationBuilder(manager: SimulationDB, simulationConfig: DBConfig): Promise<void> {
+  const conf: PoolConfig = {
+    host: simulationConfig.host,
+    port: simulationConfig.port,
+    database: simulationConfig.databaseName,
+    user: simulationConfig.user,
+    password: simulationConfig.password,
+    ssl: getSSLConfig(simulationConfig.certPath),
+  } as const;
+
+  manager._simulation = new Pool(conf);
+
+  try {
+    const dbReady = await isDatabaseReady(manager._simulation);
+    readyChecks.SimulationDB = dbReady ? 'Ok' : 'err';
+  } catch (error) {
+    const err = error as Error;
+    readyChecks.SimulationDB = `err, ${util.inspect(err)}`;
+  }
+
+  manager.getSimulationMessages = async (tenantId: string, limit = 1000, offset = 0): Promise<SimulationMessage[]> => {
+    const query: PgQueryConfig = {
+      text: 'SELECT message_id AS "messageId", timestamp, endpoint, data FROM simulation_message WHERE tenant_id = $1 ORDER BY timestamp ASC LIMIT $2 OFFSET $3',
+      values: [tenantId, limit, offset],
+    };
+
+    const queryRes = await manager._simulation.query<SimulationMessage>(query);
+    return queryRes.rows;
+  };
+}

--- a/src/config/database.config.ts
+++ b/src/config/database.config.ts
@@ -21,6 +21,9 @@ export enum Database {
 
   /** Database for enrichment data. */
   ENRICHMENT = 'enrichment',
+
+  /** Database for simulation messages. */
+  SIMULATION = 'simulation',
 }
 
 const DEFAULT_DATABASE_PORT = 5432;
@@ -54,6 +57,9 @@ export const validateDatabaseConfig = (authEnabled: boolean, database: Database)
       break;
     case Database.ENRICHMENT:
       prefix = 'ENRICHMENT_DATABASE';
+      break;
+    case Database.SIMULATION:
+      prefix = 'SIMULATION_DATABASE';
       break;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
 import { LoggerService } from './services/logger';
 import { RedisService } from './services/redis';
 import type { EnrichmentDB } from './interfaces/database/EnrichmentDB';
+import type { SimulationDB } from './interfaces/database/SimulationDB';
 import { createSafeObjectFromEndpoint } from './helpers/safeObjectFromSchema';
 import {
   isBaseMessageTransaction,
@@ -48,6 +49,7 @@ export {
   type EvaluationDB,
   type RawHistoryDB,
   type EnrichmentDB,
+  type SimulationDB,
 };
 
 export type * from './interfaces';

--- a/src/interfaces/database/SimulationDB.ts
+++ b/src/interfaces/database/SimulationDB.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Pool } from 'pg';
+
+export interface SimulationMessage {
+  messageId: string;
+  timestamp: string;
+  endpoint: string;
+  data: Record<string, unknown>;
+}
+
+export interface SimulationDB {
+  _simulation: Pool;
+
+  /**
+   * Retrieve all simulation messages for a given tenant
+   * @param tenantId The tenant identifier to filter messages
+   * @param limit Maximum number of messages to return (default 1000)
+   * @param offset Number of messages to skip (default 0)
+   * @memberof SimulationDB
+   */
+  getSimulationMessages: (tenantId: string, limit?: number, offset?: number) => Promise<SimulationMessage[]>;
+}

--- a/src/interfaces/database/index.ts
+++ b/src/interfaces/database/index.ts
@@ -4,5 +4,6 @@ export type { EvaluationDB } from './EvaluationDB';
 export type { RawHistoryDB } from './RawHistoryDB';
 export type { PgQueryConfig } from '../../builders/utils';
 export type { EnrichmentDB } from './EnrichmentDB';
+export type { SimulationDB, SimulationMessage } from './SimulationDB';
 export type { QuarantineRecord } from '../DEMS/QuarantineRecord';
 export type { TrackedFields } from '../DEMS/TrackedFields';

--- a/src/services/dbManager.ts
+++ b/src/services/dbManager.ts
@@ -7,7 +7,7 @@ import { evaluationBuilder } from '../builders/evaluationBuilder';
 import { eventHistoryBuilder } from '../builders/eventHistoryBuilder';
 import { rawHistoryBuilder } from '../builders/rawHistoryBuilder';
 import { redisBuilder } from '../builders/redisBuilder';
-import { type Database, validateDatabaseConfig } from '../config/database.config';
+import { Database, validateDatabaseConfig } from '../config/database.config';
 import { validateLocalCacheConfig } from '../config/index';
 import { Cache, validateRedisConfig } from '../config/redis.config';
 import type { RedisConfig, RuleConfig } from '../interfaces';
@@ -18,6 +18,8 @@ import type { EventHistoryDB } from '../interfaces/database/EventHistoryDB';
 import type { RawHistoryDB } from '../interfaces/database/RawHistoryDB';
 import { enrichmentBuilder } from '../builders/enrichmentBuilder';
 import type { EnrichmentDB } from '../interfaces/database/EnrichmentDB';
+import { simulationBuilder } from '../builders/simulationBuilder';
+import type { SimulationDB } from '../interfaces/database/SimulationDB';
 
 export interface DatabaseManagerHooks {
   onConfigLoaded?: (config: RuleConfig) => void;
@@ -47,6 +49,7 @@ interface ManagerConfig {
   redisConfig?: RedisConfig;
   localCacheConfig?: LocalCacheConfig;
   enrichment?: DBConfig;
+  simulation?: DBConfig;
 }
 
 interface ManagerStatus {
@@ -60,7 +63,7 @@ interface ManagerStatus {
 }
 
 export type DatabaseManagerType = Partial<
-  ManagerStatus & EventHistoryDB & RawHistoryDB & EvaluationDB & ConfigurationDB & EnrichmentDB & RedisService
+  ManagerStatus & EventHistoryDB & RawHistoryDB & EvaluationDB & ConfigurationDB & EnrichmentDB & SimulationDB & RedisService
 >;
 
 type DatabaseManagerInstance<T extends ManagerConfig> = ManagerStatus &
@@ -69,6 +72,7 @@ type DatabaseManagerInstance<T extends ManagerConfig> = ManagerStatus &
   (T extends { evaluation: DBConfig } ? EvaluationDB : Record<string, unknown>) &
   (T extends { configuration: DBConfig } ? ConfigurationDB : Record<string, unknown>) &
   (T extends { enrichment: DBConfig } ? EnrichmentDB : Record<string, unknown>) &
+  (T extends { simulation: DBConfig } ? SimulationDB : Record<string, unknown>) &
   (T extends { redisConfig: RedisConfig } ? RedisService : Record<string, unknown>);
 
 /**
@@ -107,6 +111,10 @@ export async function CreateDatabaseManager<T extends ManagerConfig>(
     await enrichmentBuilder(manager as EnrichmentDB, config.enrichment);
   }
 
+  if (config.simulation) {
+    await simulationBuilder(manager as SimulationDB, config.simulation);
+  }
+
   manager.isReadyCheck = () => readyChecks;
 
   manager.quit = () => {
@@ -116,6 +124,7 @@ export async function CreateDatabaseManager<T extends ManagerConfig>(
     manager._rawHistory?.end();
     manager._evaluation?.end();
     manager._enrichment?.end();
+    manager._simulation?.end();
   };
 
   if (Object.values(readyChecks).some((status) => status !== 'Ok')) {
@@ -141,6 +150,8 @@ export async function CreateStorageManager<T extends ManagerConfig>(
       config = { ...config, ...validateRedisConfig(requireAuth) };
     } else if (currentStorage === Cache.LOCAL) {
       config = { ...config, ...validateLocalCacheConfig() };
+    } else if (currentStorage === Database.SIMULATION && !process.env.SIMULATION_DATABASE) {
+      // SIMULATION_DATABASE is optional - skip silently if not configured
     } else {
       config = { ...config, ...validateDatabaseConfig(requireAuth, currentStorage) };
     }
@@ -153,4 +164,13 @@ export async function CreateStorageManager<T extends ManagerConfig>(
   }
 }
 
-export type { ConfigurationDB, DatabaseManagerInstance, EvaluationDB, EventHistoryDB, EnrichmentDB, ManagerConfig, RawHistoryDB };
+export type {
+  ConfigurationDB,
+  DatabaseManagerInstance,
+  EvaluationDB,
+  EventHistoryDB,
+  EnrichmentDB,
+  SimulationDB,
+  ManagerConfig,
+  RawHistoryDB,
+};


### PR DESCRIPTION
## Summary

Integrates the simulation builder from the `feat-paysys-simulation-builder` WIP branch into `dev`, makes `SIMULATION_DATABASE` optional to prevent crashloops on deployments where the simulation database has not yet been provisioned, and fixes a SQL injection risk in `eventHistoryBuilder`.

## Changes

### New
- `src/builders/simulationBuilder.ts` - connects to the `simulation_message` PostgreSQL table via a pg Pool and exposes `getSimulationMessages`
- `src/interfaces/database/SimulationDB.ts` - `SimulationDB` and `SimulationMessage` interfaces
- `__tests__/simulationBuilder.test.ts` - test coverage for the new builder

### Modified
- `src/config/database.config.ts` - add `Database.SIMULATION = 'simulation'` enum value and `SIMULATION_DATABASE` prefix to the switch
- `src/services/dbManager.ts` - wire `simulationBuilder` into `CreateDatabaseManager`; add `simulation?: DBConfig` to `ManagerConfig`; add `SimulationDB` to `DatabaseManagerType` and `DatabaseManagerInstance` conditional types; add `_simulation?.end()` to `quit()`; make `SIMULATION_DATABASE` optional in `CreateStorageManager` - if the env var is not set the database is silently skipped rather than throwing at startup
- `src/builders/eventHistoryBuilder.ts` - replace string interpolation in `saveInDataModelTable` with `pgFormat('%I', tableName)` to prevent SQL injection via table name; add regex validation of table name format before query execution
- `src/interfaces/database/index.ts` - re-export `SimulationDB` and `SimulationMessage`
- `src/index.ts` - export `SimulationDB` type from the package root
- `package.json` - bump version to `8.1.0-rc.1`

## Notes

- `SIMULATION_DATABASE` is intentionally optional. Services that include `Database.SIMULATION` in their `CreateStorageManager` call will start cleanly without the env var. The `_simulation` pool will simply not be initialised, and any code paths that call simulation methods will fail at runtime if the database has not been provisioned.
- The simulation database schema (`simulation_message` table) does not yet exist in any known deployment. The env var should be added to deployment configs only once the schema is provisioned.
- Published to GitHub Packages as `@tazama-lf/frms-coe-lib@8.1.0-rc.1` with tag `rc`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Simulation database type with message retrieval capabilities.

* **Improvements**
  * Enhanced SQL injection protection with table name validation.

* **Tests**
  * Added comprehensive test coverage for Simulation database initialization and message queries.

* **Chores**
  * Bumped version to 8.1.0-rc.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->