### PR TITLE
feat(service-channel): add CloudEvents service-channel contract (Part A) (#420)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 `frms-coe-lib` is a foundational library designed to provide common functionalities and interfaces for the FRMS (Fraud Risk Management System) ecosystem. It includes utilities, data structures, and interfaces that support various components of the system. The library offers a range of features, including database management, logging, configuration management, rule evaluation, and message handling. It serves as a core dependency for other FRMS components, providing essential building blocks and standardized approaches for handling data and interactions.
 
 Key features:
+
 - **Database Management**: Interfaces and utilities for interacting with different database systems, including Postgres and Redis.
 - **Logging**: A standardized logging interface supporting various log levels and integration with external systems.
 - **Configuration**: Tools for managing application configuration, including environment variable parsing and structured configuration objects.
@@ -32,10 +33,12 @@ Key features:
 ## Installation
 
 The npm package is hosted on GitHub. Make sure you're authenticated with GitHub and have the necessary permissions to access the package (`read:packages`). Create a [`.npmrc`](https://docs.npmjs.com/cli/v9/configuring-npm/npmrc?v=true) file if you currently do not have. Add the following content:
+
 ```.rc
 @tazama-lf:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=some-secret
 ```
+
 Replace "some-secret" with your GitHub Token.
 
 To install the `frms-coe-lib` package, you can use npm.
@@ -52,17 +55,17 @@ The npm package is hosted on GitHub. Make sure you're authenticated with GitHub 
 
 Once installed, you can import the library in your project:
 
-  ```typescript
-  import { LoggerService, CreateDatabaseManager } from '@tazama-lf/frms-coe-lib';
-  ```
+```typescript
+import { LoggerService, CreateDatabaseManager } from '@tazama-lf/frms-coe-lib';
+```
 
 3. **Dependencies:**
 
-    Ensure that you have all required dependencies installed, including any specific versions of third-party packages mentioned in the package's peer dependencies.
+   Ensure that you have all required dependencies installed, including any specific versions of third-party packages mentioned in the package's peer dependencies.
 
 4. **Environment Configuration:**
 
-    Set up your environment configuration using a `.env` file or environment variables. Refer to the library's configuration requirements for details on necessary environment variables.
+   Set up your environment configuration using a `.env` file or environment variables. Refer to the library's configuration requirements for details on necessary environment variables.
 
 ## Usage
 
@@ -73,6 +76,7 @@ The `frms-coe-lib` library provides various functionalities for transaction moni
 The `CreateDatabaseManager` function initializes and manages connections to multiple databases, including Postgres and Redis. This function returns an instance of `DatabaseManagerInstance` which includes methods to interact with the databases.
 
 **Usage Example:**
+
 ```typescript
 import { CreateDatabaseManager, DatabaseManagerInstance } from '@tazama-lf/frms-coe-lib';
 
@@ -83,12 +87,11 @@ const dbConfig = {
     user: 'username',
     password: 'password',
     certPath: 'path-to-cert',
-  }
+  },
 };
 
 let databaseManager: DatabaseManagerInstance<typeof dbConfig>;
 databaseManager = await CreateDatabaseManager(dbConfig);
-
 ```
 
 ### 2. **Logger Service**
@@ -96,6 +99,7 @@ databaseManager = await CreateDatabaseManager(dbConfig);
 The `LoggerService` class provides logging functionality, supporting different log levels like `info`, `debug`, `warn`, and `error`. It can also log messages to a GRPC service.
 
 **Usage Example:**
+
 ```typescript
 import { LoggerService } from '@tazama-lf/frms-coe-lib';
 
@@ -111,6 +115,7 @@ logger.error(new Error('This is an error message'));
 The `Apm` class integrates with Elastic APM to track performance and errors. It provides methods to start transactions and spans.
 
 **Usage Example:**
+
 ```typescript
 import { Apm } from '@tazama-lf/frms-coe-lib';
 
@@ -135,6 +140,7 @@ transaction.end();
 The `RedisService` class provides methods to interact with Redis, including setting and getting JSON data, managing sets, and handling binary data.
 
 **Example:**
+
 ```typescript
 import { RedisService } from '@tazama-lf/frms-coe-lib';
 
@@ -235,7 +241,7 @@ The contract owns three things:
 
 - the shared `type` verb enum (reverse-DNS, past-tense, constant across deployments),
 - the `kind` map keyed by `type` (`'event' | 'command'` - `'ack'` is never a map value; it is derived from the reply subject), and
-- a thin generic `construct<T>()` wrapper plus an envelope-only `validateEnvelope()` re-check.
+- a thin generic `construct<T>()` wrapper plus an envelope-only `validateEnvelope()` re-check, and a symmetric `deserialize<T>()` that decodes wire bytes back into a `CloudEvent`.
 
 The generic `T` parameterises the `data` payload and is compile-time only; envelope validation never inspects `data`.
 
@@ -246,8 +252,8 @@ import { construct, validateEnvelope, ServiceChannelType, type NetworkMapActivat
 
 const event = construct<NetworkMapActivatedData>({
   type: ServiceChannelType.NETWORK_MAP_ACTIVATED, // 'org.tazama.network-map.activated'
-  source: 'event-director',                       // the participant's '/'-free FUNCTION_NAME
-  subject: 'tenant-a/001@1.0.0',                   // the entity the event is about
+  source: 'event-director', // the participant's '/'-free FUNCTION_NAME
+  subject: 'tenant-a/001@1.0.0', // the entity the event is about
   data: { cfg: '001@1.0.0', tenantId: 'tenant-a' }, // identifier-only; consumers re-fetch the map
 });
 
@@ -255,6 +261,19 @@ validateEnvelope(event); // true, or throws on a malformed envelope
 ```
 
 `construct()` defaults `datacontenttype` to `application/json` and lets the SDK generate a fresh `id` per message. The SDK validates the envelope on build (strict mode) and throws on a malformed envelope.
+
+**Deserializing on the consumer:** a producer puts the event on the wire as structured-mode JSON bytes (`new TextEncoder().encode(JSON.stringify(event))`). `deserialize<T>()` is the symmetric decode boundary - it reconstructs the `CloudEvent<T>` and, like `construct()`, validates the envelope on build (it throws on non-JSON bytes or a malformed envelope). Consumers use it instead of importing the `cloudevents` SDK directly, so the wrapper module stays the only place that depends on the SDK.
+
+```typescript
+import { deserialize, validateEnvelope, type NetworkMapActivatedData } from '@tazama-lf/frms-coe-lib';
+
+// `bytes` is the Uint8Array delivered on the service-channel subscription
+const event = deserialize<NetworkMapActivatedData>(bytes);
+validateEnvelope(event); // re-check at the consumer boundary; true, or throws
+
+event.type; // 'org.tazama.network-map.activated'
+event.data; // { cfg, tenantId } - identifier-only; the consumer re-fetches the map
+```
 
 **Acknowledgements** are not a bespoke schema - an ack is itself a service-channel CloudEvent. It reuses the triggering message's `type`, is minted its own fresh `id`, and back-references the trigger via `data.correlationId` (the trigger's `id`) alongside the execution result:
 
@@ -275,11 +294,11 @@ import { inAudience, SERVICE_CHANNEL_AUDIENCE } from '@tazama-lf/frms-coe-lib';
 
 const identity = { class: SERVICE_CHANNEL_AUDIENCE.TYPOLOGY_PROCESSOR, functionName: 'typology-001@1.0.0' };
 
-inAudience(undefined, identity);            // true  (broadcast)
-inAudience('all', identity);                // true
+inAudience(undefined, identity); // true  (broadcast)
+inAudience('all', identity); // true
 inAudience('typology-processor', identity); // true  (class token)
 inAudience('typology-001@1.0.0', identity); // true  (own processor name)
-inAudience('event-director', identity);     // false
+inAudience('event-director', identity); // false
 ```
 
 **`FUNCTION_NAME` guard:** because a participant's `FUNCTION_NAME` composes the CloudEvents `source`, it must be `/`-free. `validateFunctionName()` (also enforced by `validateProcessorConfig`) fails fast at startup when `FUNCTION_NAME` contains a `/`. Dots stay legal, so versioned names such as `typology-001@1.0.0` are accepted.
@@ -288,82 +307,82 @@ inAudience('event-director', identity);     // false
 
 1. **ProtoBuf Module**
 
-  - **Class**: `ProtoGrpcType`
-    - **Description**: Contains definitions related to Google Protocol Buffers for message types.
-    - **Methods**:
-      - `google.protobuf.Empty`: Represents an empty message.
-      - `lumberjack.LogLevel`: Enum representing log levels.
-      - `lumberjack.LogMessage`: Represents a log message.
-      - `lumberjack.Lumberjack`: Represents the Lumberjack service with methods like `SendLog`.
+- **Class**: `ProtoGrpcType`
+  - **Description**: Contains definitions related to Google Protocol Buffers for message types.
+  - **Methods**:
+    - `google.protobuf.Empty`: Represents an empty message.
+    - `lumberjack.LogLevel`: Enum representing log levels.
+    - `lumberjack.LogMessage`: Represents a log message.
+    - `lumberjack.Lumberjack`: Represents the Lumberjack service with methods like `SendLog`.
 
 2. **Logger Service**
 
-  - **Class**: `LoggerService`
-    - **Description**: Provides logging capabilities, including sending logs to Lumberjack via gRPC or using Pino for ElasticSearch.
-    - **Methods**:
-      - `log(message: string, serviceOperation?: string, id?: string, callback?: LogCallback): void`: Logs a message.
-      - `debug(message: string, serviceOperation?: string, id?: string, callback?: LogCallback): void`: Logs a debug message.
-      - `trace(message: string, serviceOperation?: string, id?: string, callback?: LogCallback): void`: Logs a trace message.
-      - `warn(message: string, serviceOperation?: string, id?: string, callback?: LogCallback): void`: Logs a warning message.
-      - `error(message: string | Error, innerError?: unknown, serviceOperation?: string, id?: string, callback?: LogCallback): void`: Logs an error message.
-      - `fatal(message: string | Error, innerError?: unknown, serviceOperation?: string, id?: string, callback?: LogCallback): void`: Logs a fatal error message.
+- **Class**: `LoggerService`
+  - **Description**: Provides logging capabilities, including sending logs to Lumberjack via gRPC or using Pino for ElasticSearch.
+  - **Methods**:
+    - `log(message: string, serviceOperation?: string, id?: string, callback?: LogCallback): void`: Logs a message.
+    - `debug(message: string, serviceOperation?: string, id?: string, callback?: LogCallback): void`: Logs a debug message.
+    - `trace(message: string, serviceOperation?: string, id?: string, callback?: LogCallback): void`: Logs a trace message.
+    - `warn(message: string, serviceOperation?: string, id?: string, callback?: LogCallback): void`: Logs a warning message.
+    - `error(message: string | Error, innerError?: unknown, serviceOperation?: string, id?: string, callback?: LogCallback): void`: Logs an error message.
+    - `fatal(message: string | Error, innerError?: unknown, serviceOperation?: string, id?: string, callback?: LogCallback): void`: Logs a fatal error message.
 
 3. **Database Manager**
 
-  - **Class**: `DatabaseManager`
-    - **Description**: Manages database connections and interactions, including configuration, event history, raw transactions and evaluation databases.
-    - **Methods**:
-      - `CreateDatabaseManager<T>(config: T): Promise<DatabaseManagerInstance<T>>`: Creates a database manager instance.
-      - `isReadyCheck(): any`: Checks if the database services are ready.
-      - `quit(): void`: Closes all database connections.
+- **Class**: `DatabaseManager`
+  - **Description**: Manages database connections and interactions, including configuration, event history, raw transactions and evaluation databases.
+  - **Methods**:
+    - `CreateDatabaseManager<T>(config: T): Promise<DatabaseManagerInstance<T>>`: Creates a database manager instance.
+    - `isReadyCheck(): any`: Checks if the database services are ready.
+    - `quit(): void`: Closes all database connections.
 
 4. **Apm Service**
 
-  - **Class**: Apm
-    - **Description**: Provides APM (Application Performance Management) integration using Elastic APM.
-    - **Methods**:
-      - `startTransaction(name: string, options?: TransactionOptions): apm.Transaction | null`: Starts a new transaction.
-      - `startSpan(name: string): apm.Span | null`: Starts a new span.
-      - `getCurrentTraceparent(): string | null`: Retrieves the current traceparent.
+- **Class**: Apm
+  - **Description**: Provides APM (Application Performance Management) integration using Elastic APM.
+  - **Methods**:
+    - `startTransaction(name: string, options?: TransactionOptions): apm.Transaction | null`: Starts a new transaction.
+    - `startSpan(name: string): apm.Span | null`: Starts a new span.
+    - `getCurrentTraceparent(): string | null`: Retrieves the current traceparent.
 
 5. **Redis Service**
 
-  - **Class**: RedisService
-    - **Description**: Provides methods for interacting with Redis, including setting and getting data.
-    - **Methods**:
-      - `getJson(key: string): Promise<string>`: Retrieves a JSON value from Redis.
-      - `getBuffer(key: string): Promise<Record<string, unknown>>`: Retrieves a buffer value from Redis.
-      - `getMemberValues(key: string): Promise<Array<Record<string, unknown>>>`: Retrieves members of a Redis set.
-      - `deleteKey(key: string): Promise<void>`: Deletes a key from Redis.
-      - `setJson(key: string, value: string, expire: number): Promise<void>`: Sets a JSON value in Redis with an expiration time.
-      - `set(key: string, value: RedisData, expire: number): Promise<void>`: Sets a value in Redis with an expiration time.
-      - `setAdd(key: string, value: Record<string, unknown>): Promise<void>`: Adds a value to a Redis set.
-      - `addOneGetAll(key: string, value: Record<string, unknown>): Promise<Array<Record<string, unknown>>>`: Adds a value to a Redis set and retrieves all members.
-      - `addOneGetCount(key: string, value: Record<string, unknown>): Promise<number>`: Adds a value to a Redis set and retrieves the count of members.
-      - `quit(): void`: Closes the Redis connection.
+- **Class**: RedisService
+  - **Description**: Provides methods for interacting with Redis, including setting and getting data.
+  - **Methods**:
+    - `getJson(key: string): Promise<string>`: Retrieves a JSON value from Redis.
+    - `getBuffer(key: string): Promise<Record<string, unknown>>`: Retrieves a buffer value from Redis.
+    - `getMemberValues(key: string): Promise<Array<Record<string, unknown>>>`: Retrieves members of a Redis set.
+    - `deleteKey(key: string): Promise<void>`: Deletes a key from Redis.
+    - `setJson(key: string, value: string, expire: number): Promise<void>`: Sets a JSON value in Redis with an expiration time.
+    - `set(key: string, value: RedisData, expire: number): Promise<void>`: Sets a value in Redis with an expiration time.
+    - `setAdd(key: string, value: Record<string, unknown>): Promise<void>`: Adds a value to a Redis set.
+    - `addOneGetAll(key: string, value: Record<string, unknown>): Promise<Array<Record<string, unknown>>>`: Adds a value to a Redis set and retrieves all members.
+    - `addOneGetCount(key: string, value: Record<string, unknown>): Promise<number>`: Adds a value to a Redis set and retrieves the count of members.
+    - `quit(): void`: Closes the Redis connection.
 
 6. **Protobuf Utilities**
 
-  - **Functions**:
-    - `createMessageBuffer(data: Record<string, unknown>): Buffer | undefined`: Creates a message buffer from a data object.
-    - `createLogBuffer(data: Record<string, unknown>): Buffer | undefined`: Creates a log buffer from a data object.
-    - `decodeLogBuffer(buffer: Buffer): LogMessageType | undefined`: Decodes a log buffer into a `LogMessageType`.
+- **Functions**:
+  - `createMessageBuffer(data: Record<string, unknown>): Buffer | undefined`: Creates a message buffer from a data object.
+  - `createLogBuffer(data: Record<string, unknown>): Buffer | undefined`: Creates a log buffer from a data object.
+  - `decodeLogBuffer(buffer: Buffer): LogMessageType | undefined`: Decodes a log buffer into a `LogMessageType`.
 
 7. **Service-Channel Contract**
 
-  - **Functions / Values**:
-    - `construct<T>(props): CloudEvent<T>`: Builds a service-channel CloudEvent (defaults `datacontenttype`, generates `id`, validates the envelope on build).
-    - `validateEnvelope<T>(event: CloudEvent<T>): boolean`: Envelope-only re-check via the SDK's non-generic `validate()`.
-    - `inAudience(audience: string | undefined, identity): boolean`: The drift-proof audience gate.
-    - `ServiceChannelType`: The reverse-DNS `type` verb enum.
-    - `serviceChannelKind`: The `type` -> `'event' | 'command'` map.
-    - `SERVICE_CHANNEL_AUDIENCE`: The fixed class/broadcast addressing tokens.
+- **Functions / Values**:
+  - `construct<T>(props): CloudEvent<T>`: Builds a service-channel CloudEvent (defaults `datacontenttype`, generates `id`, validates the envelope on build).
+  - `validateEnvelope<T>(event: CloudEvent<T>): boolean`: Envelope-only re-check via the SDK's non-generic `validate()`.
+  - `inAudience(audience: string | undefined, identity): boolean`: The drift-proof audience gate.
+  - `ServiceChannelType`: The reverse-DNS `type` verb enum.
+  - `serviceChannelKind`: The `type` -> `'event' | 'command'` map.
+  - `SERVICE_CHANNEL_AUDIENCE`: The fixed class/broadcast addressing tokens.
 
 ## Configuration
 
 ### Environment Variables
 
-In our system, all environment variables are processed using a validation algorithm that converts them into configurations for each third-party service. Validation is triggered during the instantiation of each class object, such as when creating an instance of `databaseManager` via the `CreateStorageManager` function. 
+In our system, all environment variables are processed using a validation algorithm that converts them into configurations for each third-party service. Validation is triggered during the instantiation of each class object, such as when creating an instance of `databaseManager` via the `CreateStorageManager` function.
 
 ### Third-Party Services
 
@@ -398,6 +417,7 @@ The third-party services we support include:
 To see what are the variables required for each service please refer to VARIABLES.md document
 
 ### Configuration Options
+
 The ManagerConfig interface allows you to define which databases and services you wish to use. Each service can be optionally included in the configuration:
 
 - **Event History Database**: Access and manage event history data. `Optional`
@@ -426,7 +446,9 @@ const { db } = await CreateStorageManager([Database.CONFIGURATION], false, hooks
 ```
 
 ### Usage Example
+
 The JSON object example for dbManage configuration
+
 ```typescript
 {
     eventHistory: {

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   - [3. **Apm Integration**](#3-apm-integration)
   - [4. **Redis Service**](#4-redis-service)
   - [5. **Schema-Safe Dot Notation Access**](#5-schema-safe-dot-notation-access)
+  - [6. **Service-Channel Contract (CloudEvents)**](#6-service-channel-contract-cloudevents)
 - [Modules and Classes](#modules-and-classes)
 - [Configuration](#configuration)
   - [Environment Variables](#environment-variables)
@@ -226,6 +227,63 @@ const currency = safeObject.storyamount.currency;
 
 For non-Pacs002 flows, `TxTp`, `TenantId`, `MsgId`, and `Payload` are required. `endpointPath` is optional and reserved for schema-driven processing.
 
+### 6. **Service-Channel Contract (CloudEvents)**
+
+The service-channel contract is the single source of truth for inter-service notifications (e.g. network-map activation). It is the [CloudEvents 1.0](https://cloudevents.io/) structured-mode JSON profile, implemented over the official `cloudevents` SDK, so the producer (admin-service) and every consumer (event-director, typology-processor, event-adjudicator) share one definition and cannot drift.
+
+The contract owns three things:
+
+- the shared `type` verb enum (reverse-DNS, past-tense, constant across deployments),
+- the `kind` map keyed by `type` (`'event' | 'command'` - `'ack'` is never a map value; it is derived from the reply subject), and
+- a thin generic `construct<T>()` wrapper plus an envelope-only `validateEnvelope()` re-check.
+
+The generic `T` parameterises the `data` payload and is compile-time only; envelope validation never inspects `data`.
+
+**Constructing and validating an event:**
+
+```typescript
+import { construct, validateEnvelope, ServiceChannelType, type NetworkMapActivatedData } from '@tazama-lf/frms-coe-lib';
+
+const event = construct<NetworkMapActivatedData>({
+  type: ServiceChannelType.NETWORK_MAP_ACTIVATED, // 'org.tazama.network-map.activated'
+  source: 'event-director',                       // the participant's '/'-free FUNCTION_NAME
+  subject: 'tenant-a/001@1.0.0',                   // the entity the event is about
+  data: { cfg: '001@1.0.0', tenantId: 'tenant-a' }, // identifier-only; consumers re-fetch the map
+});
+
+validateEnvelope(event); // true, or throws on a malformed envelope
+```
+
+`construct()` defaults `datacontenttype` to `application/json` and lets the SDK generate a fresh `id` per message. The SDK validates the envelope on build (strict mode) and throws on a malformed envelope.
+
+**Acknowledgements** are not a bespoke schema - an ack is itself a service-channel CloudEvent. It reuses the triggering message's `type`, is minted its own fresh `id`, and back-references the trigger via `data.correlationId` (the trigger's `id`) alongside the execution result:
+
+```typescript
+import { construct, type ServiceChannelAck } from '@tazama-lf/frms-coe-lib';
+
+const ack = construct<ServiceChannelAck>({
+  type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+  source: 'typology-001@1.0.0',
+  data: { correlationId: event.id, outcome: 'success' }, // error? optional on failure
+});
+```
+
+**Audience addressing** is owned by the contract: a fixed class/broadcast vocabulary plus a single, drift-proof gate. Each participant supplies only its own identity; the gate encodes the one rule - act iff `audience` is absent, `all`, the participant's class token, or its own processor name. (`audience` is reserved and not emitted on the wire in the MVP.)
+
+```typescript
+import { inAudience, SERVICE_CHANNEL_AUDIENCE } from '@tazama-lf/frms-coe-lib';
+
+const identity = { class: SERVICE_CHANNEL_AUDIENCE.TYPOLOGY_PROCESSOR, functionName: 'typology-001@1.0.0' };
+
+inAudience(undefined, identity);            // true  (broadcast)
+inAudience('all', identity);                // true
+inAudience('typology-processor', identity); // true  (class token)
+inAudience('typology-001@1.0.0', identity); // true  (own processor name)
+inAudience('event-director', identity);     // false
+```
+
+**`FUNCTION_NAME` guard:** because a participant's `FUNCTION_NAME` composes the CloudEvents `source`, it must be `/`-free. `validateFunctionName()` (also enforced by `validateProcessorConfig`) fails fast at startup when `FUNCTION_NAME` contains a `/`. Dots stay legal, so versioned names such as `typology-001@1.0.0` are accepted.
+
 ## Modules and Classes
 
 1. **ProtoBuf Module**
@@ -290,6 +348,16 @@ For non-Pacs002 flows, `TxTp`, `TenantId`, `MsgId`, and `Payload` are required. 
     - `createMessageBuffer(data: Record<string, unknown>): Buffer | undefined`: Creates a message buffer from a data object.
     - `createLogBuffer(data: Record<string, unknown>): Buffer | undefined`: Creates a log buffer from a data object.
     - `decodeLogBuffer(buffer: Buffer): LogMessageType | undefined`: Decodes a log buffer into a `LogMessageType`.
+
+7. **Service-Channel Contract**
+
+  - **Functions / Values**:
+    - `construct<T>(props): CloudEvent<T>`: Builds a service-channel CloudEvent (defaults `datacontenttype`, generates `id`, validates the envelope on build).
+    - `validateEnvelope<T>(event: CloudEvent<T>): boolean`: Envelope-only re-check via the SDK's non-generic `validate()`.
+    - `inAudience(audience: string | undefined, identity): boolean`: The drift-proof audience gate.
+    - `ServiceChannelType`: The reverse-DNS `type` verb enum.
+    - `serviceChannelKind`: The `type` -> `'event' | 'command'` map.
+    - `SERVICE_CHANNEL_AUDIENCE`: The fixed class/broadcast addressing tokens.
 
 ## Configuration
 

--- a/__tests__/logger.test.ts
+++ b/__tests__/logger.test.ts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { LoggerService } from '../src/services/logger';
+import type { ProcessorConfig } from '../src/config/processor.config';
+
+const processorConfig: ProcessorConfig = {
+  maxCPU: 1,
+  functionName: 'test-fn',
+  nodeEnv: 'test',
+};
+
+describe('LoggerService - undefined attribute gating', () => {
+  let previousLogLevel: string | undefined;
+
+  beforeAll(() => {
+    previousLogLevel = process.env.LOG_LEVEL;
+    // trace activates every log-level callback
+    process.env.LOG_LEVEL = 'trace';
+  });
+
+  afterAll(() => {
+    if (previousLogLevel === undefined) {
+      delete process.env.LOG_LEVEL;
+    } else {
+      process.env.LOG_LEVEL = previousLogLevel;
+    }
+  });
+
+  let infoSpy: jest.SpyInstance;
+  let traceSpy: jest.SpyInstance;
+  let debugSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    traceSpy = jest.spyOn(console, 'trace').mockImplementation(() => undefined);
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('when no serviceOperation or id is supplied', () => {
+    it('omits the serviceOperation and id keys on an info log', () => {
+      const sut = new LoggerService(processorConfig);
+
+      sut.log('connected to nats');
+
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      const record = infoSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(record.message).toBe('connected to nats');
+      expect(Object.prototype.hasOwnProperty.call(record, 'serviceOperation')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(record, 'id')).toBe(false);
+    });
+
+    it('omits the keys on trace, debug and warn logs', () => {
+      const sut = new LoggerService(processorConfig);
+
+      sut.trace('trace line');
+      sut.debug('debug line');
+      sut.warn('warn line');
+
+      for (const spy of [traceSpy, debugSpy, warnSpy]) {
+        const record = spy.mock.calls[0][0] as Record<string, unknown>;
+        expect(Object.prototype.hasOwnProperty.call(record, 'serviceOperation')).toBe(false);
+        expect(Object.prototype.hasOwnProperty.call(record, 'id')).toBe(false);
+      }
+    });
+
+    it('omits the keys on an error log', () => {
+      const sut = new LoggerService(processorConfig);
+
+      sut.error('boom');
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const record = errorSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(record.message).toBe('boom');
+      expect(Object.prototype.hasOwnProperty.call(record, 'serviceOperation')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(record, 'id')).toBe(false);
+    });
+  });
+
+  describe('when serviceOperation and id are supplied', () => {
+    it('includes both keys on an info log', () => {
+      const sut = new LoggerService(processorConfig);
+
+      sut.log('processing', 'handleTransaction', 'txn-123');
+
+      const record = infoSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(record).toMatchObject({
+        message: 'processing',
+        serviceOperation: 'handleTransaction',
+        id: 'txn-123',
+      });
+    });
+
+    it('includes both keys on an error log', () => {
+      const sut = new LoggerService(processorConfig);
+
+      sut.error('boom', undefined, 'handleTransaction', 'txn-123');
+
+      const record = errorSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(record).toMatchObject({
+        message: 'boom',
+        serviceOperation: 'handleTransaction',
+        id: 'txn-123',
+      });
+    });
+  });
+
+  describe('when only one of serviceOperation or id is supplied', () => {
+    it('includes serviceOperation and omits the absent id', () => {
+      const sut = new LoggerService(processorConfig);
+
+      sut.log('partial', 'handleTransaction');
+
+      const record = infoSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(record.serviceOperation).toBe('handleTransaction');
+      expect(Object.prototype.hasOwnProperty.call(record, 'id')).toBe(false);
+    });
+
+    it('includes id and omits the absent serviceOperation', () => {
+      const sut = new LoggerService(processorConfig);
+
+      sut.log('partial', undefined, 'txn-123');
+
+      const record = infoSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(record.id).toBe('txn-123');
+      expect(Object.prototype.hasOwnProperty.call(record, 'serviceOperation')).toBe(false);
+    });
+  });
+
+  describe('error formatting variants', () => {
+    it('omits the keys when logging an Error object with no metadata', () => {
+      const sut = new LoggerService(processorConfig);
+
+      sut.error(new Error('explosion'));
+
+      const record = errorSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(record.message).toContain('explosion');
+      expect(Object.prototype.hasOwnProperty.call(record, 'serviceOperation')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(record, 'id')).toBe(false);
+    });
+
+    it('omits the keys when an innerError is supplied without metadata', () => {
+      const sut = new LoggerService(processorConfig);
+
+      sut.error('outer', new Error('inner'));
+
+      const record = errorSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(record.message).toContain('outer');
+      expect(record.message).toContain('inner');
+      expect(Object.prototype.hasOwnProperty.call(record, 'serviceOperation')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(record, 'id')).toBe(false);
+    });
+  });
+
+  describe('fatal delegates to error', () => {
+    it('omits the keys on a bare fatal log', () => {
+      const sut = new LoggerService(processorConfig);
+
+      sut.fatal('catastrophe');
+
+      const record = errorSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(record.message).toBe('catastrophe');
+      expect(Object.prototype.hasOwnProperty.call(record, 'serviceOperation')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(record, 'id')).toBe(false);
+    });
+  });
+});

--- a/__tests__/serviceChannel.test.ts
+++ b/__tests__/serviceChannel.test.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  ServiceChannelType,
+  serviceChannelKind,
+  construct,
+  validateEnvelope,
+  SERVICE_CHANNEL_AUDIENCE,
+  inAudience,
+} from '../src/helpers/serviceChannel';
+import type { NetworkMapActivatedData, ServiceChannelAck, ServiceChannelKind, ServiceChannelAudienceClass } from '../src/interfaces';
+
+describe('service-channel contract', () => {
+  describe('type verb enum (AC#2 / CC-C13)', () => {
+    test('carries the reverse-DNS network-map.activated verb constant', () => {
+      expect(ServiceChannelType.NETWORK_MAP_ACTIVATED).toBe('org.tazama.network-map.activated');
+    });
+
+    test('does NOT ship the deferred deactivated verb in the MVP', () => {
+      expect(Object.values(ServiceChannelType)).not.toContain('org.tazama.network-map.deactivated');
+    });
+  });
+
+  describe('kind map keyed by type (AC#2 / CC-C09)', () => {
+    test('every type verb declares a kind', () => {
+      for (const type of Object.values(ServiceChannelType)) {
+        expect(serviceChannelKind[type]).toBeDefined();
+      }
+    });
+
+    test('network-map.activated is kind "event"', () => {
+      expect(serviceChannelKind[ServiceChannelType.NETWORK_MAP_ACTIVATED]).toBe('event');
+    });
+
+    test('no map entry resolves to "ack" (ack is derived from the reply subject, not the type map)', () => {
+      for (const kind of Object.values(serviceChannelKind)) {
+        expect(kind === 'event' || kind === 'command').toBe(true);
+        expect(kind).not.toBe('ack');
+      }
+    });
+
+    test('the kind-map value type excludes "ack" at compile time', () => {
+      const kind: 'event' | 'command' = serviceChannelKind[ServiceChannelType.NETWORK_MAP_ACTIVATED];
+      expect(kind).toBeDefined();
+      // @ts-expect-error - 'ack' must NOT be assignable as a kind-map value (Record<ServiceChannelType, 'event' | 'command'>)
+      const bad: (typeof serviceChannelKind)[keyof typeof serviceChannelKind] = 'ack';
+      expect(bad).toBe('ack');
+    });
+  });
+
+  describe('generic construct<T>() wrapper (AC#3 / AC#4)', () => {
+    const data: NetworkMapActivatedData = { cfg: '001@1.0.0', tenantId: 'tenant-a' };
+
+    test('builds a CloudEvents 1.0 structured envelope with sensible defaults', () => {
+      const event = construct<NetworkMapActivatedData>({
+        type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+        source: 'event-director',
+        subject: 'tenant-a/001@1.0.0',
+        data,
+      });
+
+      expect(event.specversion).toBe('1.0');
+      expect(event.type).toBe('org.tazama.network-map.activated');
+      expect(event.datacontenttype).toBe('application/json');
+      expect(typeof event.id).toBe('string');
+      expect(event.id.length).toBeGreaterThan(0);
+      expect(event.data).toEqual(data);
+    });
+
+    test('every message gets its own fresh SDK-generated id', () => {
+      const a = construct<NetworkMapActivatedData>({ type: ServiceChannelType.NETWORK_MAP_ACTIVATED, source: 'event-director', data });
+      const b = construct<NetworkMapActivatedData>({ type: ServiceChannelType.NETWORK_MAP_ACTIVATED, source: 'event-director', data });
+      expect(a.id).not.toBe(b.id);
+    });
+
+    test('throws on a malformed envelope (SDK strict validation on build)', () => {
+      // missing required `source`
+      expect(() => construct<NetworkMapActivatedData>({ type: ServiceChannelType.NETWORK_MAP_ACTIVATED, data } as never)).toThrow();
+    });
+
+    test('the ack rides the SAME generic envelope (it is a service-channel CloudEvent, not a bespoke schema)', () => {
+      const ack = construct<ServiceChannelAck>({
+        type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+        source: 'typology-001@1.0.0',
+        subject: 'tenant-a/001@1.0.0',
+        data: { correlationId: 'evt-123', outcome: 'success' },
+      });
+
+      expect(ack.type).toBe('org.tazama.network-map.activated');
+      expect(ack.data).toEqual({ correlationId: 'evt-123', outcome: 'success' });
+      expect(validateEnvelope(ack)).toBe(true);
+    });
+  });
+
+  describe('envelope re-check via the SDK non-generic validate() (AC#4)', () => {
+    test('validateEnvelope returns true for a well-formed event', () => {
+      const event = construct<NetworkMapActivatedData>({
+        type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+        source: 'event-director',
+        data: { cfg: '001@1.0.0', tenantId: 'tenant-a' },
+      });
+      expect(validateEnvelope(event)).toBe(true);
+    });
+  });
+
+  describe('audience addressing vocabulary + gate (AC#5)', () => {
+    test('exposes the fixed class/broadcast token enum', () => {
+      expect(SERVICE_CHANNEL_AUDIENCE.EVENT_DIRECTOR).toBe('event-director');
+      expect(SERVICE_CHANNEL_AUDIENCE.TYPOLOGY_PROCESSOR).toBe('typology-processor');
+      expect(SERVICE_CHANNEL_AUDIENCE.RULE_PROCESSOR).toBe('rule-processor');
+      expect(SERVICE_CHANNEL_AUDIENCE.EVENT_ADJUDICATOR).toBe('event-adjudicator');
+      expect(SERVICE_CHANNEL_AUDIENCE.ALL).toBe('all');
+    });
+
+    const identity = { class: SERVICE_CHANNEL_AUDIENCE.TYPOLOGY_PROCESSOR, functionName: 'typology-001@1.0.0' };
+
+    test('acts when audience is absent (broadcast)', () => {
+      expect(inAudience(undefined, identity)).toBe(true);
+    });
+
+    test('acts when audience is "all"', () => {
+      expect(inAudience(SERVICE_CHANNEL_AUDIENCE.ALL, identity)).toBe(true);
+    });
+
+    test('acts when audience matches its class token', () => {
+      expect(inAudience(SERVICE_CHANNEL_AUDIENCE.TYPOLOGY_PROCESSOR, identity)).toBe(true);
+    });
+
+    test('acts when audience names its own processor name', () => {
+      expect(inAudience('typology-001@1.0.0', identity)).toBe(true);
+    });
+
+    test('ignores when audience is a different class token', () => {
+      expect(inAudience(SERVICE_CHANNEL_AUDIENCE.EVENT_DIRECTOR, identity)).toBe(false);
+    });
+
+    test('ignores when audience names a different processor', () => {
+      expect(inAudience('rule_001', identity)).toBe(false);
+    });
+  });
+
+  describe('compile-time payload type aliases (AC#3)', () => {
+    test('network-map.activated data is identifier-only { cfg, tenantId }', () => {
+      const data: NetworkMapActivatedData = { cfg: '001@1.0.0', tenantId: 'tenant-a' };
+      expect(data).toEqual({ cfg: '001@1.0.0', tenantId: 'tenant-a' });
+    });
+
+    test('ack data carries { correlationId, outcome, error? }', () => {
+      const ack: ServiceChannelAck = { correlationId: 'evt-123', outcome: 'success' };
+      const failed: ServiceChannelAck = { correlationId: 'evt-123', outcome: 'failure', error: 'boom' };
+      expect(ack.correlationId).toBe('evt-123');
+      expect(failed.error).toBe('boom');
+    });
+
+    test('ack outcome is loosely typed (any string is accepted)', () => {
+      const ack: ServiceChannelAck = { correlationId: 'evt-123', outcome: 'PARTIALLY_APPLIED' };
+      expect(ack.outcome).toBe('PARTIALLY_APPLIED');
+    });
+
+    test('kind union and audience-class type exist', () => {
+      const kind: ServiceChannelKind = 'ack';
+      const klass: ServiceChannelAudienceClass = 'event-director';
+      expect(kind).toBe('ack');
+      expect(klass).toBe('event-director');
+    });
+  });
+});

--- a/__tests__/serviceChannel.test.ts
+++ b/__tests__/serviceChannel.test.ts
@@ -234,4 +234,79 @@ describe('service-channel contract', () => {
       expect(deserializeFromBarrel).toBe(deserialize);
     });
   });
+
+  describe('audience setter on construct props (#426 - Part A write-side)', () => {
+    const data: NetworkMapActivatedData = { cfg: '001@1.0.0', tenantId: 'tenant-a' };
+    const encode = (event: CloudEvent<NetworkMapActivatedData>): Uint8Array => new TextEncoder().encode(JSON.stringify(event));
+
+    test('AC2: stamps the supplied audience as a readable extension attribute', () => {
+      const event = construct<NetworkMapActivatedData>({
+        type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+        source: 'admin-service',
+        subject: 'tenant-a/001@1.0.0',
+        data,
+        audience: SERVICE_CHANNEL_AUDIENCE.EVENT_ADJUDICATOR,
+      });
+      expect(event.audience).toBe('event-adjudicator');
+    });
+
+    test('AC2: the audience survives the producer serialize -> deserialize wire round-trip', () => {
+      const bytes = encode(
+        construct<NetworkMapActivatedData>({
+          type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+          source: 'admin-service',
+          data,
+          audience: SERVICE_CHANNEL_AUDIENCE.EVENT_ADJUDICATOR,
+        }),
+      );
+      const decoded = deserialize<NetworkMapActivatedData>(bytes);
+      expect(decoded.audience).toBe('event-adjudicator');
+    });
+
+    test('AC1: accepts a free-form processor name as well as a class token', () => {
+      const event = construct<NetworkMapActivatedData>({
+        type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+        source: 'admin-service',
+        data,
+        audience: 'typology-001@1.0.0',
+      });
+      expect(event.audience).toBe('typology-001@1.0.0');
+    });
+
+    test('AC3: omitting audience leaves it undefined (broadcast default - no regression)', () => {
+      const event = construct<NetworkMapActivatedData>({
+        type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+        source: 'admin-service',
+        data,
+      });
+      expect(event.audience).toBeUndefined();
+    });
+
+    test('AC4: a produced audience is inAudience for a matching identity and not for a non-matching one (write -> read symmetry)', () => {
+      const addressedToEa = construct<NetworkMapActivatedData>({
+        type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+        source: 'admin-service',
+        data,
+        audience: SERVICE_CHANNEL_AUDIENCE.EVENT_ADJUDICATOR,
+      });
+      const wire = deserialize<NetworkMapActivatedData>(encode(addressedToEa)).audience;
+      expect(wire).toBe('event-adjudicator');
+      const audience = wire as string;
+      // functionName is deliberately distinct from the audience value so a positive match can only come via the class-token branch.
+      expect(inAudience(audience, { class: SERVICE_CHANNEL_AUDIENCE.EVENT_ADJUDICATOR, functionName: 'event-adjudicator-001@1.0.0' })).toBe(
+        true,
+      );
+      expect(inAudience(audience, { class: SERVICE_CHANNEL_AUDIENCE.TYPOLOGY_PROCESSOR, functionName: 'typology-001@1.0.0' })).toBe(false);
+    });
+
+    test('AC5: validateEnvelope remains true with the audience extension present', () => {
+      const event = construct<NetworkMapActivatedData>({
+        type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+        source: 'admin-service',
+        data,
+        audience: SERVICE_CHANNEL_AUDIENCE.EVENT_ADJUDICATOR,
+      });
+      expect(validateEnvelope(event)).toBe(true);
+    });
+  });
 });

--- a/__tests__/serviceChannel.test.ts
+++ b/__tests__/serviceChannel.test.ts
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { CloudEvent } from 'cloudevents';
+import { deserialize as deserializeFromBarrel } from '../src';
 import {
   ServiceChannelType,
   serviceChannelKind,
   construct,
   validateEnvelope,
+  deserialize,
   SERVICE_CHANNEL_AUDIENCE,
   inAudience,
 } from '../src/helpers/serviceChannel';
@@ -162,6 +165,73 @@ describe('service-channel contract', () => {
       const klass: ServiceChannelAudienceClass = 'event-director';
       expect(kind).toBe('ack');
       expect(klass).toBe('event-director');
+    });
+  });
+
+  describe('consumer deserialize<T>() boundary (#422)', () => {
+    const data: NetworkMapActivatedData = { cfg: '001@1.0.0', tenantId: 'tenant-a' };
+    const encode = (event: CloudEvent<NetworkMapActivatedData>): Uint8Array => new TextEncoder().encode(JSON.stringify(event));
+
+    test('round-trips a produced event back to an equivalent CloudEvent (the wire format admin-service publishes)', () => {
+      const original = construct<NetworkMapActivatedData>({
+        type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+        source: 'admin-service',
+        subject: 'tenant-a/001@1.0.0',
+        data,
+      });
+      const decoded = deserialize<NetworkMapActivatedData>(encode(original));
+      expect(decoded.id).toBe(original.id);
+      expect(decoded.type).toBe(original.type);
+      expect(decoded.source).toBe(original.source);
+      expect(decoded.subject).toBe(original.subject);
+      expect(decoded.datacontenttype).toBe('application/json');
+      expect(decoded.data).toEqual(data);
+    });
+
+    test('the decoded envelope passes validateEnvelope (the consumer re-check at the deserialize boundary)', () => {
+      const bytes = encode(
+        construct<NetworkMapActivatedData>({ type: ServiceChannelType.NETWORK_MAP_ACTIVATED, source: 'admin-service', data }),
+      );
+      expect(validateEnvelope(deserialize<NetworkMapActivatedData>(bytes))).toBe(true);
+    });
+
+    test('carries the data type parameter through to the decoded event', () => {
+      const bytes = encode(
+        construct<NetworkMapActivatedData>({ type: ServiceChannelType.NETWORK_MAP_ACTIVATED, source: 'admin-service', data }),
+      );
+      const decoded = deserialize<NetworkMapActivatedData>(bytes);
+      expect(decoded.data?.tenantId).toBe('tenant-a');
+      expect(decoded.data?.cfg).toBe('001@1.0.0');
+    });
+
+    test('round-trips a data-less event (data is optional in the envelope)', () => {
+      const bytes = encode(construct<NetworkMapActivatedData>({ type: ServiceChannelType.NETWORK_MAP_ACTIVATED, source: 'admin-service' }));
+      const decoded = deserialize<NetworkMapActivatedData>(bytes);
+      expect(decoded.data).toBeUndefined();
+      expect(validateEnvelope(decoded)).toBe(true);
+    });
+
+    test('throws on non-JSON wire bytes', () => {
+      const garbage = new TextEncoder().encode('not-json{');
+      expect(() => deserialize<NetworkMapActivatedData>(garbage)).toThrow();
+    });
+
+    test('throws on empty wire bytes', () => {
+      expect(() => deserialize<NetworkMapActivatedData>(new Uint8Array())).toThrow();
+    });
+
+    test('throws on valid JSON that is not an envelope object', () => {
+      const notAnObject = new TextEncoder().encode('42');
+      expect(() => deserialize<NetworkMapActivatedData>(notAnObject)).toThrow();
+    });
+
+    test('throws on a structurally malformed envelope (missing the required type)', () => {
+      const bytes = new TextEncoder().encode(JSON.stringify({ specversion: '1.0', id: 'evt-1', source: 'admin-service', data }));
+      expect(() => deserialize<NetworkMapActivatedData>(bytes)).toThrow();
+    });
+
+    test('is re-exported from the package barrel (public surface)', () => {
+      expect(deserializeFromBarrel).toBe(deserialize);
     });
   });
 });

--- a/__tests__/validateFunctionName.test.ts
+++ b/__tests__/validateFunctionName.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { validateFunctionName } from '../src/config/environment';
+import { validateProcessorConfig } from '../src/config/processor.config';
+
+describe('validateFunctionName (AC#6)', () => {
+  afterEach(() => {
+    delete process.env.FUNCTION_NAME;
+  });
+
+  test('throws when FUNCTION_NAME is not defined (delegates to validateEnvVar)', () => {
+    delete process.env.FUNCTION_NAME;
+    expect(() => validateFunctionName()).toThrow(Error);
+  });
+
+  test('returns the value when FUNCTION_NAME is "/"-free', () => {
+    process.env.FUNCTION_NAME = 'event-director';
+    expect(validateFunctionName()).toBe('event-director');
+  });
+
+  test('accepts dotted / versioned names (dots stay legal)', () => {
+    process.env.FUNCTION_NAME = 'typology-001@1.0.0';
+    expect(validateFunctionName()).toBe('typology-001@1.0.0');
+  });
+
+  test('throws when FUNCTION_NAME contains a "/"', () => {
+    process.env.FUNCTION_NAME = 'foo/bar';
+    expect(() => validateFunctionName()).toThrow(/FUNCTION_NAME/);
+  });
+});
+
+describe('validateProcessorConfig fails fast on a "/"-containing FUNCTION_NAME (AC#6)', () => {
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.MAX_CPU = '1';
+  });
+
+  afterAll(() => {
+    delete process.env.NODE_ENV;
+    delete process.env.MAX_CPU;
+  });
+
+  afterEach(() => {
+    delete process.env.FUNCTION_NAME;
+  });
+
+  test('throws when FUNCTION_NAME contains a "/"', () => {
+    process.env.FUNCTION_NAME = 'some/processor';
+    expect(() => validateProcessorConfig()).toThrow();
+  });
+
+  test('passes through for a "/"-free FUNCTION_NAME', () => {
+    process.env.FUNCTION_NAME = 'event-director';
+    expect(() => validateProcessorConfig()).not.toThrow();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.2.0-rc.1",
+  "version": "8.2.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "8.2.0-rc.1",
+      "version": "8.2.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.1.0-rc.2",
+  "version": "8.2.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "8.1.0-rc.2",
+      "version": "8.2.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -14,6 +14,7 @@
         "@grpc/proto-loader": "~0.7.15",
         "@types/pg": "^8.15.5",
         "@types/uuid": "^10.0.0",
+        "cloudevents": "^10.0.0",
         "dotenv": "^17.2.1",
         "elastic-apm-node": "^4.14.0",
         "ioredis": "^5.7.0",
@@ -80,7 +81,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1637,7 +1637,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2027,7 +2026,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
       "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2115,7 +2113,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -2607,7 +2604,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2681,6 +2677,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -2971,7 +3006,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -3194,7 +3228,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3566,6 +3599,55 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cloudevents": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-10.0.0.tgz",
+      "integrity": "sha512-uyzC+PpMMRawbouHO+3mlisr3QfEDObmo2pN4oTTF6dZncZgpIzdasZx0tRBFI1dMsqCLZZXMtz8cUuvYqHdbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "json-bigint": "^1.0.0",
+        "process": "^0.11.10",
+        "util": "^0.12.4",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=20 <=24"
+      }
+    },
+    "node_modules/cloudevents/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/cloudevents/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/cloudevents/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -4327,7 +4409,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4943,7 +5024,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4984,6 +5064,22 @@
         "end-of-stream": "^1.4.1"
       }
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -5018,7 +5114,6 @@
       "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.10",
         "sprintf-js": "^1.1.3",
@@ -5113,7 +5208,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -5214,7 +5308,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5565,7 +5658,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -5776,7 +5868,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -5815,6 +5906,22 @@
       "peerDependencies": {
         "@types/ioredis-mock": "^8",
         "ioredis": "^5"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5899,7 +6006,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6027,7 +6133,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -6112,7 +6217,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6208,7 +6312,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -6373,7 +6476,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -8009,7 +8111,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -8258,7 +8359,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8578,6 +8678,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-in-the-middle": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
@@ -8810,7 +8919,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9778,7 +9886,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9979,7 +10086,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10174,6 +10280,19 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10329,7 +10448,6 @@
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
       "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.2.0-rc.0",
+  "version": "8.2.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/frms-coe-lib",
-      "version": "8.2.0-rc.0",
+      "version": "8.2.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.2.0-rc.1",
+  "version": "8.2.0-rc.2",
   "description": "Tazama package library",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.2.0-rc.2",
+  "version": "8.2.0-rc.3",
   "description": "Tazama package library",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.1.0-rc.2",
+  "version": "8.2.0-rc.0",
   "description": "Tazama package library",
   "main": "lib/index.js",
   "repository": {
@@ -36,6 +36,7 @@
     "@grpc/proto-loader": "~0.7.15",
     "@types/pg": "^8.15.5",
     "@types/uuid": "^10.0.0",
+    "cloudevents": "^10.0.0",
     "dotenv": "^17.2.1",
     "elastic-apm-node": "^4.14.0",
     "ioredis": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/frms-coe-lib",
-  "version": "8.2.0-rc.0",
+  "version": "8.2.0-rc.1",
   "description": "Tazama package library",
   "main": "lib/index.js",
   "repository": {

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -44,3 +44,24 @@ export function validateEnvVar(name: string, type: 'string' | 'number' | 'boolea
       throw new Error(`Environment variable ${name} is not a valid boolean.`);
   }
 }
+
+/**
+ * Validates and retrieves the `FUNCTION_NAME` environment variable, failing fast when it contains a `/`.
+ *
+ * The `/`-free invariant keeps the composed service-channel `source`
+ * (`${SERVICE_CHANNEL_SOURCE_URI_PREFIX}${FUNCTION_NAME}`) safely recoverable as the trailing path
+ * segment. Dots stay legal (versioned names such as `typology-001@1.0.0`); this is not a broader
+ * NATS-charset check.
+ *
+ * @returns {string} - The validated `/`-free function name.
+ * @throws {Error} - If `FUNCTION_NAME` is not defined, or contains a `/`.
+ */
+export function validateFunctionName(): string {
+  const functionName = validateEnvVar('FUNCTION_NAME', 'string').toString();
+
+  if (functionName.includes('/')) {
+    throw new Error('Environment variable FUNCTION_NAME must not contain a path separator (/).');
+  }
+
+  return functionName;
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
 import { validateDatabaseConfig } from './database.config';
-import { validateEnvVar } from './environment';
+import { validateEnvVar, validateFunctionName } from './environment';
 import { validateLocalCacheConfig } from './localcache.config';
 import { validateAPMConfig, validateLogConfig } from './monitoring.config';
 import { validateProcessorConfig } from './processor.config';
@@ -9,6 +9,7 @@ export {
   validateAPMConfig,
   validateDatabaseConfig,
   validateEnvVar,
+  validateFunctionName,
   validateLocalCacheConfig,
   validateLogConfig,
   validateProcessorConfig,

--- a/src/config/processor.config.ts
+++ b/src/config/processor.config.ts
@@ -1,4 +1,4 @@
-import { validateEnvVar } from '.';
+import { validateEnvVar, validateFunctionName } from '.';
 
 /**
  * Interface representing the configuration for a processor.
@@ -57,7 +57,7 @@ export const validateProcessorConfig = (additionalEnvironmentVariables?: Additio
 
   const _processorConfig: ProcessorConfig = {
     maxCPU: parseInt(maxCPU, 10),
-    functionName: validateEnvVar('FUNCTION_NAME', 'string').toString(),
+    functionName: validateFunctionName(),
     nodeEnv,
   };
   return { ..._processorConfig, ..._additionalConfiguration };

--- a/src/helpers/serviceChannel.ts
+++ b/src/helpers/serviceChannel.ts
@@ -38,6 +38,13 @@ export interface ServiceChannelEventProps<T> {
   id?: string;
   time?: string;
   datacontenttype?: string;
+  /**
+   * Optional audience the event is addressed to, set by a producer as a CloudEvents extension attribute
+   * and read back on the consumer via `inAudience`. Accepts a closed class token (`ServiceChannelAudienceClass`)
+   * or a free-form processor name; omitting it leaves the event a broadcast (`audience === undefined`).
+   * The `string & {}` constituent keeps autocomplete for the class tokens while still admitting any processor name.
+   */
+  audience?: ServiceChannelAudienceClass | (string & {});
 }
 
 /**

--- a/src/helpers/serviceChannel.ts
+++ b/src/helpers/serviceChannel.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { CloudEvent } from 'cloudevents';
+import type { ServiceChannelAudienceClass, ServiceChannelKind } from '../interfaces';
+
+/**
+ * The shared service-channel `type` verb enum (CC-C13): reverse-DNS, past-tense, constant across all
+ * deployments. The `org.tazama` prefix names the project that defines the semantics; the deployer's
+ * domain lives in `source`, never here.
+ *
+ * `org.tazama.network-map.deactivated` is deferred from the MVP verb set (an emergency kill-switch);
+ * it is promoted additively only if it must notify consumers.
+ */
+export const ServiceChannelType = {
+  NETWORK_MAP_ACTIVATED: 'org.tazama.network-map.activated',
+} as const;
+
+export type ServiceChannelType = (typeof ServiceChannelType)[keyof typeof ServiceChannelType];
+
+/**
+ * The `kind` map keyed by the `type` verb (CC-C09). Constrained to `'event' | 'command'`: `ack` is
+ * structurally impossible as a map value because an ack reuses the triggering message's `type` and is
+ * instead derived from the reply subject.
+ */
+export const serviceChannelKind: Record<ServiceChannelType, Exclude<ServiceChannelKind, 'ack'>> = {
+  [ServiceChannelType.NETWORK_MAP_ACTIVATED]: 'event',
+};
+
+/**
+ * Construction-time properties for a service-channel CloudEvent, parameterised on the `data` payload `T`.
+ * The generic `T` is compile-time only and is never runtime-checked against `data`.
+ */
+export interface ServiceChannelEventProps<T> {
+  type: ServiceChannelType;
+  source: string;
+  data?: T;
+  subject?: string;
+  id?: string;
+  time?: string;
+  datacontenttype?: string;
+}
+
+/**
+ * Thin generic wrapper over the `cloudevents` SDK so every participant constructs identically.
+ * Defaults `datacontenttype` to `application/json` (the structured-mode profile) and lets the SDK
+ * generate a fresh `id`. The SDK validates the envelope on build (strict mode) and throws on a
+ * malformed envelope.
+ */
+export const construct = <T>(props: ServiceChannelEventProps<T>): CloudEvent<T> =>
+  new CloudEvent<T>({ datacontenttype: 'application/json', ...props });
+
+/**
+ * Pass-through to the SDK's non-generic, envelope-only `validate()` for a re-check at the consumer
+ * deserialize boundary. The SDK has no `validate<T>()`; `data` shape is never runtime-checked here.
+ */
+export const validateEnvelope = <T>(event: CloudEvent<T>): boolean => event.validate();
+
+/**
+ * The fixed class/broadcast addressing tokens owned by the contract (`all` = broadcast). The open
+ * processor-name space is deployment-defined and intentionally not enumerated.
+ */
+export const SERVICE_CHANNEL_AUDIENCE = {
+  EVENT_DIRECTOR: 'event-director',
+  TYPOLOGY_PROCESSOR: 'typology-processor',
+  RULE_PROCESSOR: 'rule-processor',
+  EVENT_ADJUDICATOR: 'event-adjudicator',
+  ALL: 'all',
+} as const satisfies Record<string, ServiceChannelAudienceClass>;
+
+/** A participant's self-identity, supplied from its own deploy-time environment. */
+export interface ServiceChannelIdentity {
+  class: ServiceChannelAudienceClass;
+  functionName: string;
+}
+
+/**
+ * The single, drift-proof audience gate: a participant acts iff `audience` is absent, `all`, its own
+ * class token, or its own (free-form) processor name. The contract supplies the vocabulary; each
+ * consumer supplies its identity.
+ */
+export const inAudience = (audience: string | undefined, identity: ServiceChannelIdentity): boolean => {
+  if (audience === undefined || audience === SERVICE_CHANNEL_AUDIENCE.ALL) {
+    return true;
+  }
+  return audience === identity.class || audience === identity.functionName;
+};

--- a/src/helpers/serviceChannel.ts
+++ b/src/helpers/serviceChannel.ts
@@ -56,6 +56,15 @@ export const construct = <T>(props: ServiceChannelEventProps<T>): CloudEvent<T> 
 export const validateEnvelope = <T>(event: CloudEvent<T>): boolean => event.validate();
 
 /**
+ * The symmetric decode counterpart to `construct<T>()`: reconstructs a `CloudEvent<T>` from the
+ * structured-mode JSON bytes a producer puts on the wire (`TextEncoder().encode(JSON.stringify(event))`).
+ * The SDK validates the envelope on construction (strict mode) and throws on malformed bytes or a
+ * malformed envelope. The generic `T` is compile-time only; `data` shape is never runtime-checked.
+ */
+export const deserialize = <T>(bytes: Uint8Array): CloudEvent<T> =>
+  new CloudEvent<T>(JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>);
+
+/**
  * The fixed class/broadcast addressing tokens owned by the contract (`all` = broadcast). The open
  * processor-name space is deployment-defined and intentionally not enumerated.
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,14 @@ import {
   isPain001Transaction,
   isPain013Transaction,
 } from './helpers/transactionTypeGuards';
+import {
+  ServiceChannelType,
+  serviceChannelKind,
+  construct,
+  validateEnvelope,
+  SERVICE_CHANNEL_AUDIENCE,
+  inAudience,
+} from './helpers/serviceChannel';
 
 export {
   CreateDatabaseManager,
@@ -40,6 +48,12 @@ export {
   isPain001Transaction,
   isPain013Transaction,
   validateTableName,
+  ServiceChannelType,
+  serviceChannelKind,
+  construct,
+  validateEnvelope,
+  SERVICE_CHANNEL_AUDIENCE,
+  inAudience,
   type ConfigurationDB,
   type DatabaseManagerHooks,
   type DatabaseManagerInstance,

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
   serviceChannelKind,
   construct,
   validateEnvelope,
+  deserialize,
   SERVICE_CHANNEL_AUDIENCE,
   inAudience,
 } from './helpers/serviceChannel';
@@ -52,6 +53,7 @@ export {
   serviceChannelKind,
   construct,
   validateEnvelope,
+  deserialize,
   SERVICE_CHANNEL_AUDIENCE,
   inAudience,
   type ConfigurationDB,

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -18,3 +18,4 @@ export type * from './event-flow/EntityConditionEdge';
 export type * from './database';
 export type * from './DEMS/QuarantineRecord';
 export type * from './DEMS/TrackedFields';
+export type * from './service-channel';

--- a/src/interfaces/service-channel/Ack.ts
+++ b/src/interfaces/service-channel/Ack.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The `data` payload of an acknowledgement.
+ *
+ * An ack is itself a service-channel CloudEvent (not a bespoke schema): it reuses the triggering
+ * message's `type`, is minted its own fresh `id`, and back-references the triggering message via
+ * `correlationId` (the triggering message's `id`). The correlation lives in `data` - alongside the
+ * execution result (`outcome` / `error`) - rather than an envelope extension, because the ack's
+ * `data` is itself the response metadata.
+ */
+export interface ServiceChannelAck {
+  correlationId: string;
+  outcome: string;
+  error?: string;
+}

--- a/src/interfaces/service-channel/NetworkMapActivatedData.ts
+++ b/src/interfaces/service-channel/NetworkMapActivatedData.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The `data` payload for `org.tazama.network-map.activated`.
+ *
+ * Identifier-only by design: consumers re-fetch the full network map from the source of truth.
+ * Erased at compile time (pure type), so it adds zero runtime footprint.
+ */
+export interface NetworkMapActivatedData {
+  cfg: string;
+  tenantId: string;
+}

--- a/src/interfaces/service-channel/audience.ts
+++ b/src/interfaces/service-channel/audience.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The fixed class/broadcast addressing vocabulary owned by the contract.
+ *
+ * A message's `audience` is either one of these closed class tokens (`all` = broadcast) or a free-form,
+ * deployment-defined processor name (not enumerated here). See {@link inAudience} for the match rule.
+ */
+export type ServiceChannelAudienceClass = 'event-director' | 'typology-processor' | 'rule-processor' | 'event-adjudicator' | 'all';

--- a/src/interfaces/service-channel/index.ts
+++ b/src/interfaces/service-channel/index.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type * from './kind';
+export type * from './audience';
+export type * from './NetworkMapActivatedData';
+export type * from './Ack';

--- a/src/interfaces/service-channel/kind.ts
+++ b/src/interfaces/service-channel/kind.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The message-role axis of the service-channel profile (compile-time only - not on the wire in the MVP).
+ *
+ * `event` and `command` are derived by both sides from the shared `type` enum keyed by `type`;
+ * `ack` is derived by a consumer from the reply subject (CC-C14). Because `ack` reuses the triggering
+ * message's `type`, it is never resolvable from the type-keyed `kind` map - hence the map is constrained
+ * to `'event' | 'command'` and this union is used only for typing ack payloads.
+ */
+export type ServiceChannelKind = 'event' | 'command' | 'ack';

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -28,6 +28,17 @@ const LOGLEVEL = config.logLevel.toLowerCase();
 type LogFunc = (message: string, serviceOperation?: string, id?: string, callback?: LogCallback) => void;
 type ErrorFunc = (message: string | Error, innerError?: unknown, serviceOperation?: string, id?: string, callback?: LogCallback) => void;
 
+const buildLogRecord = (message: string, serviceOperation?: string, id?: string): Record<string, string> => {
+  const record: Record<string, string> = { message };
+  if (serviceOperation !== undefined) {
+    record.serviceOperation = serviceOperation;
+  }
+  if (id !== undefined) {
+    record.id = id;
+  }
+  return record;
+};
+
 const createErrorFn =
   (logger: Console | Logger, grpcClient?: LumberjackGRPCService): ErrorFunc =>
   (message: string | Error, innerError?: unknown, serviceOperation?: string, id?: string, callback?: LogCallback): void => {
@@ -44,7 +55,7 @@ const createErrorFn =
     if (grpcClient) {
       grpcClient.log(errMessage, 'error', serviceOperation, id, callback);
     } else {
-      logger.error({ message: errMessage, serviceOperation, id });
+      logger.error(buildLogRecord(errMessage, serviceOperation, id));
     }
   };
 
@@ -55,7 +66,7 @@ const createLogCallback = (level: LogLevel, logger: Console | Logger, grpcClient
         if (grpcClient) {
           grpcClient.log(message, level, serviceOperation, id, callback);
         } else {
-          logger.trace({ message, serviceOperation, id });
+          logger.trace(buildLogRecord(message, serviceOperation, id));
         }
       };
     case 'debug':
@@ -63,7 +74,7 @@ const createLogCallback = (level: LogLevel, logger: Console | Logger, grpcClient
         if (grpcClient) {
           grpcClient.log(message, level, serviceOperation, id, callback);
         } else {
-          logger.debug({ message, serviceOperation, id });
+          logger.debug(buildLogRecord(message, serviceOperation, id));
         }
       };
     case 'warn':
@@ -71,7 +82,7 @@ const createLogCallback = (level: LogLevel, logger: Console | Logger, grpcClient
         if (grpcClient) {
           grpcClient.log(message, level, serviceOperation, id, callback);
         } else {
-          logger.warn({ message, serviceOperation, id });
+          logger.warn(buildLogRecord(message, serviceOperation, id));
         }
       };
     case 'fatal':
@@ -80,7 +91,7 @@ const createLogCallback = (level: LogLevel, logger: Console | Logger, grpcClient
           grpcClient.log(message, level, serviceOperation, id, callback);
         } else {
           // NOTE: 'fatal(...)' method is not available on a `console` logger
-          logger.error({ message, serviceOperation, id });
+          logger.error(buildLogRecord(message, serviceOperation, id));
         }
       };
     default:
@@ -88,7 +99,7 @@ const createLogCallback = (level: LogLevel, logger: Console | Logger, grpcClient
         if (grpcClient) {
           grpcClient.log(message, 'info', serviceOperation, id, callback);
         } else {
-          logger.info({ message, serviceOperation, id });
+          logger.info(buildLogRecord(message, serviceOperation, id));
         }
       };
   }


### PR DESCRIPTION
## Part A - shared CloudEvents service-channel contract

Resolves the first slice of #420: the shared service-channel contract that is the single source of truth for inter-service notifications (network-map activation in the MVP). It is the [CloudEvents 1.0](https://cloudevents.io/) structured-mode JSON profile, implemented over the official `cloudevents` SDK, so the producer (admin-service) and every consumer share one definition and cannot drift.

This PR also delivers #422 - the consumer-side `deserialize<T>()` decode wrapper - folded in here because it completes #420's AC4 (see "Consumer decode boundary" below).

### What this adds

**Type verb enum + kind map**
- `ServiceChannelType` - reverse-DNS, past-tense verb enum (`org.tazama.network-map.activated`), constant across deployments.
- `serviceChannelKind` - a map keyed by `type` to `'event' | 'command'`. `'ack'` is deliberately **never** a map value; an ack is derived from the reply subject and reuses the triggering message's `type`, so it cannot be keyed in a type-indexed map. This is enforced at compile time via `Record<ServiceChannelType, Exclude<ServiceChannelKind, 'ack'>>`.

**Generic wrapper**
- `construct<T>(props)` - thin wrapper over the SDK that defaults `datacontenttype` to `application/json`, lets the SDK mint a fresh `id` per message, and validates the envelope on build. `T` parameterises `data` and is compile-time only.
- `validateEnvelope<T>(event)` - envelope-only re-check via the SDK's non-generic `validate()`. Never inspects `data`.
- `deserialize<T>(bytes)` - the symmetric decode counterpart to `construct<T>()`. Reconstructs a `CloudEvent<T>` from the structured-mode JSON wire bytes a producer publishes (`TextEncoder().encode(JSON.stringify(event))`), validating the envelope on build and throwing on non-JSON bytes or a malformed envelope.

**Consumer decode boundary (#422)**
- AC4 of #420 requires `cloudevents` to be imported by **only** the wrapper module. Without a decode wrapper, every consumer must import the SDK directly to reconstruct an event - breaking that goal. `deserialize<T>()` closes that gap, so adding it completes AC4 as written rather than being new scope. The primitive surfaced just-in-time as event-director (#390) becomes the first real consumer to force the decode path the producer-first delivery never exercised.

**Audience addressing**
- `SERVICE_CHANNEL_AUDIENCE` - the fixed class/broadcast token vocabulary.
- `inAudience(audience, identity)` - the single drift-proof gate: act iff `audience` is absent, `all`, the participant's class token, or its own processor name.
- **Audience setter (#426)** - `ServiceChannelEventProps<T>` now carries an optional `audience` (typed `ServiceChannelAudienceClass | (string & {})`), so a producer can address an event to a tier or processor. `construct` stamps it as a CloudEvents extension attribute that survives the `deserialize` wire round-trip and feeds `inAudience` on the consumer; omitting it leaves the event a broadcast (`audience === undefined`). This is the write-side counterpart to the shipped `inAudience` read gate and unblocks the admin-service cascade reload-mode wavefront (#446).

**Payload contracts (type-only)**
- `NetworkMapActivatedData` (identifier-only - consumers re-fetch the map), `ServiceChannelAck`, plus the `ServiceChannelKind` / `ServiceChannelAudienceClass` types, surfaced type-only through the interfaces barrel.

**FUNCTION_NAME guard**
- `validateFunctionName()` fails fast when `FUNCTION_NAME` contains a `/`, because the value composes the CloudEvents `source`. Dots stay legal, so versioned names like `typology-001@1.0.0` are accepted. Wired into `validateProcessorConfig`.

### Drive-by fix - undefined log attributes (#425)

Folded in on this branch: the shared `LoggerService` previously spread `{ message, serviceOperation, id }` unconditionally at every object emit site, so every log record carried `serviceOperation: undefined, id: undefined` whenever a caller omitted them (the common case). The record is now built conditionally via a `buildLogRecord` helper that omits each key when its value is `undefined`, applied at `createErrorFn` and every `createLogCallback` branch. The `grpcClient` positional path is unchanged, and there is no pino config change (key omission is sink-agnostic). Covered by a new `__tests__/logger.test.ts` (10 cases: omit-when-undefined across info/trace/debug/warn/error/fatal, include-when-present, and partial-metadata).

This is the narrow Part 1 of the logger defect. The separate sidecar-disconnect regression is tracked in #424 and is **not** addressed here.

### Tests
- `__tests__/serviceChannel.test.ts` - type enum, kind map (runtime + `@ts-expect-error` compile lock that `'ack'` is not a map value), ack envelope round-trip, `construct` defaults, the `inAudience` truth table, the `deserialize<T>()` boundary (wire round-trip, decoded-envelope re-check, type-param carry-through, data-less round-trip, barrel re-export, plus malformed cases: non-JSON, empty, non-object JSON, missing `type`), and the audience setter (#426 - stamp + wire round-trip, free-form processor name, broadcast default, write-to-read symmetry through `inAudience`, envelope validity).
- `__tests__/validateFunctionName.test.ts` - dotted/versioned names legal, `/` throws, `validateProcessorConfig` fails fast.
- `__tests__/logger.test.ts` - undefined `serviceOperation`/`id` keys omitted, present values retained, partial-metadata cases (#425).
- Full suite: 200/200 passing; lint and build clean.

### Packaging
- Adds the `cloudevents` dependency.
- Bumps the package to `8.2.0-rc.3` and publishes the `rc` dist-tag to GitHub Packages. `rc.1` delivered the service-channel contract; `rc.2` additionally folds in the #425 logger fix; `rc.3` adds the #426 audience setter. This is the new shared baseline consumers pin.

### Docs
- README service-channel section documents the `deserialize<T>()` consumer decode boundary, and the README is reformatted to restore prettier compliance (pre-existing drift).

### Out of scope (tracked separately)
- Transport / startup wiring - frms-coe-startup-lib#279 (Part B).
- Publish seam in admin-service - admin-service#444.
- Consumer behaviour - Parts D-F.
- Logger sidecar-disconnect regression - #424.

### Note on issue linking
This PR targets `dev` (non-default), so closing keywords do not link or auto-close. #420, #422, #425 and #426 are linked manually via the Development sidebar; the close will be done when the change reaches the default branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Service-Channel CloudEvents 1.0 contract helpers for typed event construction, envelope validation, structured-mode deserialization, and audience addressing.
  * Strengthened `FUNCTION_NAME` validation to reject `/`.
* **Documentation**
  * Expanded README with the Service-Channel contract and refreshed installation/usage examples.
* **Bug Fixes**
  * Updated non-gRPC logging to omit `serviceOperation`/`id` when not provided.
* **Tests**
  * Added/extended coverage for the contract, `FUNCTION_NAME` validation, and logging metadata behavior.
* **Dependencies**
  * Bumped package version and updated the CloudEvents SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
