### PR TITLE
fix: grant pull-requests:read to publish caller

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   packages: write
   contents: read
+  pull-requests: read
 
 jobs:
   publish:


### PR DESCRIPTION
Reusable publish@v1 requires pull-requests:read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation permissions to enable read-only access to pull request information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->